### PR TITLE
Fix O(N²) BM25 index rebuild regression in incremental add_documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ build/
 .eggs/
 *.whl
 
+# hatch-vcs generated
+locallens/_version.py
+
 # Virtual environments
 .venv/
 venv/

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -26,6 +26,7 @@ async def lifespan(app: FastAPI):
     yield
     # Shutdown
     watcher.stop()
+    bm25.flush()
 
 
 app = FastAPI(title="LocalLens API", version="0.1.0", lifespan=lifespan)

--- a/backend/app/services/bm25.py
+++ b/backend/app/services/bm25.py
@@ -34,4 +34,4 @@ def _set_persist_path(path: Path) -> None:
 
     Kept symmetrical with the CLI-side wrapper for tests that exercise both.
     """
-    _index.set_persist_path(Path(path))
+    _index.set_persist_path(path)

--- a/backend/app/services/bm25.py
+++ b/backend/app/services/bm25.py
@@ -1,126 +1,37 @@
-"""BM25 keyword index for hybrid search.
+"""BM25 keyword index for hybrid search (backend side).
 
-Maintains an in-memory BM25 index alongside the Qdrant vector index.
-The corpus is persisted as JSON so it survives restarts.
+Thin wrapper around ``locallens._bm25_core._Bm25Index``. The module-level
+API is preserved for callers: ``build_index``, ``add_documents``,
+``remove_documents``, ``search``, ``load``, ``is_loaded``, plus ``flush``.
+
+Persists to ``data/bm25_index.json`` (relative to the process CWD) by default.
 """
 
-import json
+from __future__ import annotations
+
 import logging
-import re
 from pathlib import Path
 
-from rank_bm25 import BM25Okapi
+from locallens._bm25_core import _Bm25Index
 
 logger = logging.getLogger(__name__)
 
 _BM25_PATH = Path("data/bm25_index.json")
 
-_bm25: BM25Okapi | None = None
-_doc_ids: list[str] = []
-_corpus_texts: list[str] = []
+_index = _Bm25Index(_BM25_PATH, logger=logger)
+
+build_index = _index.build_index
+add_documents = _index.add_documents
+remove_documents = _index.remove_documents
+search = _index.search
+load = _index.load
+is_loaded = _index.is_loaded
+flush = _index.flush
 
 
-def _tokenize(text: str) -> list[str]:
-    """Simple whitespace + punctuation tokenizer."""
-    return re.findall(r"\w+", text.lower())
+def _set_persist_path(path: Path) -> None:
+    """Redirect the underlying index to a new on-disk path.
 
-
-def build_index(documents: list[dict]) -> None:
-    """Build BM25 index from documents.
-
-    Each document should have 'id' and 'chunk_text' keys.
+    Kept symmetrical with the CLI-side wrapper for tests that exercise both.
     """
-    global _bm25, _doc_ids, _corpus_texts
-
-    _doc_ids = [str(d["id"]) for d in documents]
-    _corpus_texts = [d.get("chunk_text", "") for d in documents]
-    tokenized = [_tokenize(t) for t in _corpus_texts]
-
-    _bm25 = BM25Okapi(tokenized) if tokenized else None
-
-    _save()
-    logger.info("BM25 index built with %d documents", len(_doc_ids))
-
-
-def add_documents(documents: list[dict]) -> None:
-    """Add documents to existing index (rebuilds)."""
-    global _bm25, _doc_ids, _corpus_texts
-
-    for d in documents:
-        doc_id = str(d["id"])
-        if doc_id in _doc_ids:
-            idx = _doc_ids.index(doc_id)
-            _corpus_texts[idx] = d.get("chunk_text", "")
-        else:
-            _doc_ids.append(doc_id)
-            _corpus_texts.append(d.get("chunk_text", ""))
-
-    tokenized = [_tokenize(t) for t in _corpus_texts]
-    _bm25 = BM25Okapi(tokenized) if tokenized else None
-    _save()
-
-
-def remove_documents(doc_ids: list[str]) -> None:
-    """Remove documents by ID and rebuild."""
-    global _bm25, _doc_ids, _corpus_texts
-
-    id_set = set(doc_ids)
-    pairs = [
-        (did, txt) for did, txt in zip(_doc_ids, _corpus_texts) if did not in id_set
-    ]
-    if pairs:
-        _doc_ids, _corpus_texts = map(list, zip(*pairs))
-    else:
-        _doc_ids, _corpus_texts = [], []
-
-    tokenized = [_tokenize(t) for t in _corpus_texts]
-    _bm25 = BM25Okapi(tokenized) if tokenized else None
-    _save()
-
-
-def search(query: str, top_k: int = 10) -> list[tuple[str, float]]:
-    """Search BM25 index. Returns list of (doc_id, score) pairs."""
-    if _bm25 is None or not _doc_ids:
-        return []
-
-    tokens = _tokenize(query)
-    if not tokens:
-        return []
-
-    scores = _bm25.get_scores(tokens)
-    ranked = sorted(enumerate(scores), key=lambda x: x[1], reverse=True)
-
-    results = []
-    for idx, score in ranked[:top_k]:
-        if score > 0:
-            results.append((_doc_ids[idx], float(score)))
-    return results
-
-
-def load() -> None:
-    """Load persisted BM25 index from disk."""
-    global _bm25, _doc_ids, _corpus_texts
-
-    if not _BM25_PATH.exists():
-        return
-
-    try:
-        data = json.loads(_BM25_PATH.read_text())
-        _doc_ids = data.get("doc_ids", [])
-        _corpus_texts = data.get("corpus_texts", [])
-        tokenized = [_tokenize(t) for t in _corpus_texts]
-        _bm25 = BM25Okapi(tokenized) if tokenized else None
-        logger.info("BM25 index loaded: %d documents", len(_doc_ids))
-    except Exception as exc:
-        logger.warning("Could not load BM25 index: %s", exc)
-
-
-def _save() -> None:
-    """Persist BM25 corpus to disk."""
-    _BM25_PATH.parent.mkdir(parents=True, exist_ok=True)
-    data = {"doc_ids": _doc_ids, "corpus_texts": _corpus_texts}
-    _BM25_PATH.write_text(json.dumps(data))
-
-
-def is_loaded() -> bool:
-    return _bm25 is not None and len(_doc_ids) > 0
+    _index.set_persist_path(Path(path))

--- a/bench-results/FINDINGS.md
+++ b/bench-results/FINDINGS.md
@@ -1,0 +1,176 @@
+# LocalLens engine — pipeline benchmark findings
+
+Benchmark script: [`scripts/bench_pipeline.py`](../scripts/bench_pipeline.py)  
+Reports: `bench_200.json`, `bench_500.json`  
+Corpus: synthetic `.md`/`.txt`/`.py` files (~5 KB avg), seeded RNG (reproducible).  
+Embedder: **mocked** 384-dim vectors — HuggingFace was unreachable in the sandbox.
+Real `all-MiniLM-L6-v2` timings are referenced from published numbers below.
+
+---
+
+## Per-stage timings (200 files → 1,485 chunks)
+
+| stage                       | total    | per item   | share of end-to-end |
+| --------------------------- | -------- | ---------- | ------------------- |
+| walk                        | 30 ms    | 0.15 ms    |  0.3 %              |
+| hash (sha256)               | 53 ms    | 0.26 ms    |  0.5 %              |
+| extract (text)              | 47 ms    | 0.23 ms    |  0.4 %              |
+| chunk                       | 12 ms    | 0.06 ms    |  0.1 %              |
+| **bm25 incremental**        | **10.52 s** | **52.6 ms** | **96.9 %**     |
+| bm25 build-from-scratch     | 115 ms   | 0.08 ms    | (not in pipeline)   |
+| bm25 tokenize alone         | 42 ms    | 0.03 ms    | (subset of above)   |
+| embed batch 32 (*mock*)     | 67 ms    | 0.05 ms    |  0.6 %              |
+| qdrant edge upsert          | 131 ms   | 0.09 ms    |  1.2 %              |
+| qdrant edge has_hash (dedup)|   1 ms   | 0.004 ms   | —                   |
+| qdrant edge search          |   5 ms   | 0.35 ms    | —                   |
+| bm25 search                 |  27 ms   | 1.93 ms    | —                   |
+
+## Scaling check (500 files → 3,779 chunks)
+
+| stage                       | 200f      | 500f      | ratio  | expected (linear) |
+| --------------------------- | --------- | --------- | ------ | ----------------- |
+| walk                        | 30 ms     | 66 ms     | 2.2 ×  | 2.5 ×             |
+| hash                        | 53 ms     | 120 ms    | 2.3 ×  | 2.5 ×             |
+| chunk                       | 12 ms     | 28 ms     | 2.3 ×  | 2.5 ×             |
+| qdrant upsert (mock vecs)   | 131 ms    | — (skipped) | —    | 2.5 ×             |
+| **bm25 incremental**        | **10.5 s**| **67.7 s**| **6.4 ×** | 2.5 × → **O(n²)** |
+| bm25 search (fixed corpus)  | 27 ms     | 72 ms     | 2.7 ×  | linear in N docs  |
+
+The incremental BM25 path grows quadratically. Everything else is linear.
+
+---
+
+## Root-cause: `locallens/bm25.py::add_documents`
+
+```python
+def add_documents(documents: list[dict]) -> None:
+    ...
+    for d in documents:
+        if doc_id in _doc_ids:            # O(n) list scan per doc
+            ...
+    tokenized = [_tokenize(t) for t in _corpus_texts]   # re-tokenize whole corpus
+    _bm25 = BM25Okapi(tokenized) if tokenized else None # rebuild whole BM25 index
+    _save()                                             # rewrite whole JSON to disk
+```
+
+Called **once per file** from `indexer.py`. For N files with M chunks each:
+
+- `_doc_ids` membership check:  O(files × cumulative_chunks) ≈ O(N²·M)
+- Retokenize full corpus:        O(Σᵢ₌₁..ᴺ i·M) = O(N²·M)
+- Full JSON rewrite:             O(N²·M) bytes written across run
+- `BM25Okapi` constructor:       recomputes idf for the whole corpus every call
+
+Net effect measured: 500 files take **6.4×** longer than a linear projection.
+At 2,000 files it projects to ~18 min; at 10,000 files it's unusable.
+
+The pure-Python `rank-bm25` lib has no incremental API — it recomputes everything
+on construction — so the current design pays that cost every single add.
+
+---
+
+## What a Rust rewrite would actually buy us
+
+Ordered by real impact on end-to-end wall-clock time, assuming the BM25 bug
+above is **not** addressed yet.
+
+### 1. BM25 — huge win, but first fix the algorithm in Python
+
+**If we just stop rebuilding on every add** (batch adds, or use append-only
+counters + lazy idf), Python already does 3,779 docs in **115 ms**
+(`bm25_build_fresh`). That closes 96 % of the gap without any Rust.
+
+Only *then* does Rust start to matter. A Rust BM25 (e.g. [tantivy](https://github.com/quickwit-oss/tantivy)
+embedded, or a small pyo3 wrapper around a custom inverted index) would:
+- add proper incremental updates (no full rebuild)
+- give true on-disk persistence (no whole-file JSON rewrite)
+- make `bm25.search` 5–10× faster than `rank-bm25` on large corpora
+  (which currently iterates every doc in Python to score)
+
+**Recommendation:** fix the algorithm first; revisit Rust only if `bm25_search`
+becomes a problem (> ~5 ms/query with >50k chunks).
+
+### 2. Tokenizer (used by BM25) — modest win
+
+`bm25_tokenize` hits ~4.2 M tokens/sec in pure-Python regex. Rust can do
+30–50 M/sec easily. But at 1,485 chunks the tokenize cost is 42 ms — not a
+user-visible bottleneck until you're at 100k+ chunks.
+
+Low priority until corpus size justifies it.
+
+### 3. File hashing — only helps huge corpora
+
+Currently ~20 MB/sec throughput (pure-Python SHA-256 loop). Rust `sha2` + `rayon`
+easily hits 500 MB/sec single-threaded or multi-GB/sec with SIMD. But on a
+1 MB total corpus this saves 50 ms. Only matters if indexing multi-GB directories.
+
+### 4. Chunker — not a bottleneck
+
+58 µs per file. A Rust port would save 12 ms on a 200-file run. Skip.
+
+### 5. File walker — not a bottleneck
+
+`Path.rglob` is already C-backed via `os.scandir`. 150 µs per file on our corpus.
+Skip.
+
+### 6. Embedder — **Rust cannot help here**
+
+`sentence-transformers` → PyTorch → ATen/MKL (C++/Fortran). The Python overhead
+is <1 % of the batch-32 call. A Rust wrapper around ONNX runtime (via `candle`
+or `ort`) would give near-identical throughput because the matmul is the work.
+
+The only way to speed up embeddings is: smaller model, quantized weights, or
+GPU — orthogonal to Rust vs Python.
+
+### 7. Qdrant store — already Rust
+
+`qdrant-edge-py` is a PyO3 wrapper over Qdrant (written in Rust). Upsert is
+11k points/sec; `has_hash` is 230k lookups/sec. Nothing to rewrite.
+
+---
+
+## Bottom line
+
+1. **Before any Rust work**: fix `bm25.add_documents` to do incremental append
+   instead of full rebuild. That single change recovers ~97 % of the indexing
+   time for a 200-file corpus and is the #1 ROI change in the whole engine.
+
+2. **After that**, the remaining end-to-end breakdown (200-file corpus):
+   - Embedding: ~2 s (estimated, real model) — PyTorch, not Rust territory
+   - Qdrant upsert: ~130 ms — already Rust
+   - Hashing + extract + chunk + walk: ~140 ms — pure overhead, not worth rewriting
+   - BM25 build (once): ~115 ms
+   - BM25 search: ~2 ms/query
+
+   There is **no single stage left that would repay a Rust port** at typical
+   corpus sizes (≤ 10k files).
+
+3. **When Rust would genuinely pay off** — at scale (≥ 50k files or ≥ 1 GB
+   corpus) the candidates are:
+   - Inverted index / BM25 (tantivy or custom) — replaces rank-bm25 entirely
+   - SHA-256 hashing with SIMD + rayon parallelism
+   - Regex-based tokenizer (shared by BM25 + chunker)
+
+   All three could live in one `locallens-core` pyo3 crate, imported where
+   needed. Estimated dev cost: 2–3 weeks. Estimated speedup on a 100k-file
+   corpus: 5–10× on indexing throughput, assuming the BM25 algorithm fix is
+   also in place.
+
+---
+
+## Repro
+
+```bash
+uv sync --frozen
+uv pip install rank-bm25                          # dev-time dep
+
+# Quick smoke (skip heavy stages)
+.venv/bin/python scripts/bench_pipeline.py --files 30 --skip-embed --skip-store
+
+# Full run with mock embeddings
+.venv/bin/python scripts/bench_pipeline.py --files 200 --mock-embed --out bench-results/bench_200.json
+
+# Scaling check
+.venv/bin/python scripts/bench_pipeline.py --files 500 --mock-embed --skip-store --out bench-results/bench_500.json
+```
+
+With real HF access, drop `--mock-embed` to measure actual embedding throughput.

--- a/bench-results/FINDINGS.md
+++ b/bench-results/FINDINGS.md
@@ -1,7 +1,9 @@
 # LocalLens engine — pipeline benchmark findings
 
 Benchmark script: [`scripts/bench_pipeline.py`](../scripts/bench_pipeline.py)  
-Reports: `bench_200.json`, `bench_500.json`  
+Reports: `bench_200.json`, `bench_500.json` (pre-fix);
+`bench_200_post.json`, `bench_500_post.json` (post-fix, see the
+"Post-fix results" section at the bottom).  
 Corpus: synthetic `.md`/`.txt`/`.py` files (~5 KB avg), seeded RNG (reproducible).  
 Embedder: **mocked** 384-dim vectors — HuggingFace was unreachable in the sandbox.
 Real `all-MiniLM-L6-v2` timings are referenced from published numbers below.
@@ -174,3 +176,67 @@ uv pip install rank-bm25                          # dev-time dep
 ```
 
 With real HF access, drop `--mock-embed` to measure actual embedding throughput.
+
+---
+
+## Post-fix results
+
+Fix landed: `locallens/_bm25_core.py` replaces `rank_bm25.BM25Okapi` with a
+parameterised incremental index. Running the same bench on the same synthetic
+corpus (seeded RNG):
+
+### 200 files / 1,485 chunks
+
+| stage                       | pre-fix   | post-fix  | speedup |
+| --------------------------- | --------- | --------- | ------- |
+| walk                        | 30 ms     | 21 ms     | 1.4 ×   |
+| hash (sha256)               | 53 ms     | 42 ms     | 1.3 ×   |
+| extract                     | 47 ms     | 31 ms     | 1.5 ×   |
+| chunk                       | 12 ms     | 9 ms      | 1.3 ×   |
+| **bm25 incremental**        | **10,520 ms** | **53 ms** | **198 ×** |
+| bm25 build-from-scratch     | 115 ms    | 66 ms     | 1.7 ×   |
+| bm25 search (×14 queries)   | 27 ms     | 8 ms      | 3.4 ×   |
+| qdrant edge upsert          | 131 ms    | 118 ms    | ~1 ×    |
+| **end-to-end index**        | **10.86 s** | **0.33 s** | **33 ×** |
+
+### 500 files / 3,779 chunks (scaling check)
+
+| stage                       | pre-fix   | post-fix  | speedup |
+| --------------------------- | --------- | --------- | ------- |
+| **bm25 incremental**        | **67,699 ms** | **141 ms** | **480 ×** |
+| bm25 search (×14 queries)   | 72 ms     | 29 ms     | 2.5 ×   |
+| **end-to-end index**        | **~68 s** | **0.50 s** | **~136 ×** |
+
+### Scaling is now linear
+
+`bm25_incremental_per_file` at 200 → 500 files: **2.66 ×** for 2.5 × input.
+Pre-fix was 6.4 × for the same step — the O(N²) tail is gone.
+
+### Why so much bigger than the plan's estimate
+
+The plan targeted ≥ 35 × at 200 files and ≥ 80 × at 500 files. We beat both by
+roughly 5×. Two reasons:
+
+1. The pre-fix path wasn't just `O(N²)` — it also re-tokenized every doc and
+   re-ran `BM25Okapi.__init__` (which walks the whole corpus building its own
+   tf / df tables) on every add. Eliminating both loops together gives a
+   multiplicative win.
+2. Scoring moved from `np.array([doc.get(t, 0) for doc in self.doc_freqs])`
+   inside a NumPy helper to a direct dict lookup in a tight Python loop.
+   That's a wash on throughput but it drops ~20 ms per query at this corpus
+   size because NumPy's per-call setup overhead is gone.
+
+### What dominates wall-clock now
+
+At 200 files post-fix: `qdrant_edge_upsert` (36 %), `bm25_incremental_per_file`
+(16 %), `embed_batch_32` (16 %, mocked — real embeddings would push this to
+the top). BM25 is no longer a bottleneck at any corpus size we measured; the
+pipeline is now bounded by model inference and the vector store, as expected.
+
+### Rust revisited
+
+With this fix in, the earlier recommendation stands even more strongly:
+a Rust port of BM25 would save ~50-150 ms end-to-end at typical corpus sizes
+— well under the ~500 ms floor set by embedding + Qdrant. Revisit only if a
+user reports pain on a corpus much larger than we've measured here.
+

--- a/bench-results/FINDINGS.md
+++ b/bench-results/FINDINGS.md
@@ -183,33 +183,41 @@ With real HF access, drop `--mock-embed` to measure actual embedding throughput.
 
 Fix landed: `locallens/_bm25_core.py` replaces `rank_bm25.BM25Okapi` with a
 parameterised incremental index. Running the same bench on the same synthetic
-corpus (seeded RNG):
+corpus (seeded RNG).
+
+**Note on measurement methodology.** Pre-fix, every `add_documents` call
+persisted the whole JSON file, so the pre-fix `bm25_incremental_per_file`
+timing included persistence. Post-fix writes are deferred, so to keep the
+comparison apples-to-apples the bench now times `add_documents` per file
+**plus a single trailing `flush()`** — the exact path the CLI indexer and
+the web lifespan shutdown take. At this corpus size the flush contributes
+~1-10 ms, well inside measurement noise.
 
 ### 200 files / 1,485 chunks
 
 | stage                       | pre-fix   | post-fix  | speedup |
 | --------------------------- | --------- | --------- | ------- |
-| walk                        | 30 ms     | 21 ms     | 1.4 ×   |
-| hash (sha256)               | 53 ms     | 42 ms     | 1.3 ×   |
-| extract                     | 47 ms     | 31 ms     | 1.5 ×   |
+| walk                        | 30 ms     | 13 ms     | 2.2 ×   |
+| hash (sha256)               | 53 ms     | 30 ms     | 1.8 ×   |
+| extract                     | 47 ms     | 24 ms     | 2.0 ×   |
 | chunk                       | 12 ms     | 9 ms      | 1.3 ×   |
-| **bm25 incremental**        | **10,520 ms** | **53 ms** | **198 ×** |
+| **bm25 incremental + flush** | **10,520 ms** | **54 ms** | **195 ×** |
 | bm25 build-from-scratch     | 115 ms    | 66 ms     | 1.7 ×   |
 | bm25 search (×14 queries)   | 27 ms     | 8 ms      | 3.4 ×   |
-| qdrant edge upsert          | 131 ms    | 118 ms    | ~1 ×    |
-| **end-to-end index**        | **10.86 s** | **0.33 s** | **33 ×** |
+| qdrant edge upsert          | 131 ms    | 107 ms    | 1.2 ×   |
+| **end-to-end index**        | **10.86 s** | **0.27 s** | **40 ×** |
 
 ### 500 files / 3,779 chunks (scaling check)
 
 | stage                       | pre-fix   | post-fix  | speedup |
 | --------------------------- | --------- | --------- | ------- |
-| **bm25 incremental**        | **67,699 ms** | **141 ms** | **480 ×** |
-| bm25 search (×14 queries)   | 72 ms     | 29 ms     | 2.5 ×   |
-| **end-to-end index**        | **~68 s** | **0.50 s** | **~136 ×** |
+| **bm25 incremental + flush** | **67,699 ms** | **151 ms** | **449 ×** |
+| bm25 search (×14 queries)   | 72 ms     | 32 ms     | 2.3 ×   |
+| **end-to-end index**        | **~68 s** | **0.44 s** | **~155 ×** |
 
 ### Scaling is now linear
 
-`bm25_incremental_per_file` at 200 → 500 files: **2.66 ×** for 2.5 × input.
+`bm25_incremental_per_file` at 200 → 500 files: **2.80 ×** for 2.5 × input.
 Pre-fix was 6.4 × for the same step — the O(N²) tail is gone.
 
 ### Why so much bigger than the plan's estimate
@@ -228,8 +236,8 @@ roughly 5×. Two reasons:
 
 ### What dominates wall-clock now
 
-At 200 files post-fix: `qdrant_edge_upsert` (36 %), `bm25_incremental_per_file`
-(16 %), `embed_batch_32` (16 %, mocked — real embeddings would push this to
+At 200 files post-fix: `qdrant_edge_upsert` (39 %), `bm25_incremental_per_file`
+(20 %), `embed_batch_32` (13 %, mocked — real embeddings would push this to
 the top). BM25 is no longer a bottleneck at any corpus size we measured; the
 pipeline is now bounded by model inference and the vector store, as expected.
 
@@ -239,4 +247,5 @@ With this fix in, the earlier recommendation stands even more strongly:
 a Rust port of BM25 would save ~50-150 ms end-to-end at typical corpus sizes
 — well under the ~500 ms floor set by embedding + Qdrant. Revisit only if a
 user reports pain on a corpus much larger than we've measured here.
+
 

--- a/bench-results/bench_200.json
+++ b/bench-results/bench_200.json
@@ -1,0 +1,139 @@
+{
+  "n_files": 200,
+  "n_chunks": 1485,
+  "results": [
+    {
+      "stage": "walk",
+      "seconds": 0.0303,
+      "items": 200,
+      "per_item_ms": 0.151,
+      "note": "rglob + is_file filter"
+    },
+    {
+      "stage": "hash_sha256",
+      "seconds": 0.0526,
+      "items": 200,
+      "per_item_ms": 0.263,
+      "note": "",
+      "mb_per_sec": 18.38,
+      "total_mb": 0.97
+    },
+    {
+      "stage": "extract_text",
+      "seconds": 0.0468,
+      "items": 200,
+      "per_item_ms": 0.234,
+      "note": "",
+      "mchars_per_sec": 21.63,
+      "total_mchars": 1.01
+    },
+    {
+      "stage": "chunk",
+      "seconds": 0.0116,
+      "items": 200,
+      "per_item_ms": 0.058,
+      "note": "",
+      "total_chunks": 1485,
+      "avg_chunks_per_file": 7.42
+    },
+    {
+      "stage": "bm25_tokenize",
+      "seconds": 0.0417,
+      "items": 1485,
+      "per_item_ms": 0.028,
+      "note": "",
+      "total_tokens": 175869,
+      "tokens_per_sec": 4218589.0
+    },
+    {
+      "stage": "bm25_build_fresh",
+      "seconds": 0.1148,
+      "items": 1485,
+      "per_item_ms": 0.077,
+      "note": "build_index(all_docs)",
+      "docs_per_sec": 12935.5
+    },
+    {
+      "stage": "bm25_incremental_per_file",
+      "seconds": 10.5163,
+      "items": 200,
+      "per_item_ms": 52.581,
+      "note": "indexer.py path: add_documents() per file (O(n^2))",
+      "total_chunks": 1485,
+      "files_per_sec": 19.02
+    },
+    {
+      "stage": "bm25_search",
+      "seconds": 0.027,
+      "items": 14,
+      "per_item_ms": 1.929,
+      "note": "",
+      "queries_per_sec": 518.4
+    },
+    {
+      "stage": "embed_batch_1",
+      "seconds": 0.098,
+      "items": 1485,
+      "per_item_ms": 0.066,
+      "note": "MOCK (not real ML timing)",
+      "chunks_per_sec": 15150.1
+    },
+    {
+      "stage": "embed_batch_8",
+      "seconds": 0.0717,
+      "items": 1485,
+      "per_item_ms": 0.048,
+      "note": "MOCK (not real ML timing)",
+      "chunks_per_sec": 20723.5
+    },
+    {
+      "stage": "embed_batch_32",
+      "seconds": 0.0673,
+      "items": 1485,
+      "per_item_ms": 0.045,
+      "note": "MOCK (not real ML timing)",
+      "chunks_per_sec": 22074.8
+    },
+    {
+      "stage": "embed_batch_64",
+      "seconds": 0.0664,
+      "items": 1485,
+      "per_item_ms": 0.045,
+      "note": "MOCK (not real ML timing)",
+      "chunks_per_sec": 22349.8
+    },
+    {
+      "stage": "embed_query",
+      "seconds": 0.0006,
+      "items": 14,
+      "per_item_ms": 0.042,
+      "note": "MOCK (not real ML timing)",
+      "queries_per_sec": 23602.8
+    },
+    {
+      "stage": "qdrant_edge_upsert",
+      "seconds": 0.1307,
+      "items": 1485,
+      "per_item_ms": 0.088,
+      "note": "",
+      "points_per_sec": 11364.1
+    },
+    {
+      "stage": "qdrant_edge_has_hash",
+      "seconds": 0.0009,
+      "items": 200,
+      "per_item_ms": 0.004,
+      "note": "",
+      "lookups_per_sec": 229616.1
+    },
+    {
+      "stage": "qdrant_edge_search",
+      "seconds": 0.0049,
+      "items": 14,
+      "per_item_ms": 0.348,
+      "note": "",
+      "queries_per_sec": 2876.7
+    }
+  ],
+  "end_to_end_total_s": 10.855510125000023
+}

--- a/bench-results/bench_200_post.json
+++ b/bench-results/bench_200_post.json
@@ -1,0 +1,139 @@
+{
+  "n_files": 200,
+  "n_chunks": 1485,
+  "results": [
+    {
+      "stage": "walk",
+      "seconds": 0.0209,
+      "items": 200,
+      "per_item_ms": 0.105,
+      "note": "rglob + is_file filter"
+    },
+    {
+      "stage": "hash_sha256",
+      "seconds": 0.0418,
+      "items": 200,
+      "per_item_ms": 0.209,
+      "note": "",
+      "mb_per_sec": 23.11,
+      "total_mb": 0.97
+    },
+    {
+      "stage": "extract_text",
+      "seconds": 0.0311,
+      "items": 200,
+      "per_item_ms": 0.156,
+      "note": "",
+      "mchars_per_sec": 32.53,
+      "total_mchars": 1.01
+    },
+    {
+      "stage": "chunk",
+      "seconds": 0.0086,
+      "items": 200,
+      "per_item_ms": 0.043,
+      "note": "",
+      "total_chunks": 1485,
+      "avg_chunks_per_file": 7.42
+    },
+    {
+      "stage": "bm25_tokenize",
+      "seconds": 0.0286,
+      "items": 1485,
+      "per_item_ms": 0.019,
+      "note": "",
+      "total_tokens": 175869,
+      "tokens_per_sec": 6157589.0
+    },
+    {
+      "stage": "bm25_build_fresh",
+      "seconds": 0.0662,
+      "items": 1485,
+      "per_item_ms": 0.045,
+      "note": "build_index(all_docs)",
+      "docs_per_sec": 22416.5
+    },
+    {
+      "stage": "bm25_incremental_per_file",
+      "seconds": 0.0532,
+      "items": 200,
+      "per_item_ms": 0.266,
+      "note": "indexer.py path: add_documents() per file (O(n^2))",
+      "total_chunks": 1485,
+      "files_per_sec": 3759.68
+    },
+    {
+      "stage": "bm25_search",
+      "seconds": 0.0079,
+      "items": 14,
+      "per_item_ms": 0.567,
+      "note": "",
+      "queries_per_sec": 1762.2
+    },
+    {
+      "stage": "embed_batch_1",
+      "seconds": 0.194,
+      "items": 1485,
+      "per_item_ms": 0.131,
+      "note": "MOCK (not real ML timing)",
+      "chunks_per_sec": 7654.7
+    },
+    {
+      "stage": "embed_batch_8",
+      "seconds": 0.0488,
+      "items": 1485,
+      "per_item_ms": 0.033,
+      "note": "MOCK (not real ML timing)",
+      "chunks_per_sec": 30448.9
+    },
+    {
+      "stage": "embed_batch_32",
+      "seconds": 0.0527,
+      "items": 1485,
+      "per_item_ms": 0.035,
+      "note": "MOCK (not real ML timing)",
+      "chunks_per_sec": 28182.5
+    },
+    {
+      "stage": "embed_batch_64",
+      "seconds": 0.049,
+      "items": 1485,
+      "per_item_ms": 0.033,
+      "note": "MOCK (not real ML timing)",
+      "chunks_per_sec": 30334.9
+    },
+    {
+      "stage": "embed_query",
+      "seconds": 0.0004,
+      "items": 14,
+      "per_item_ms": 0.031,
+      "note": "MOCK (not real ML timing)",
+      "queries_per_sec": 32174.3
+    },
+    {
+      "stage": "qdrant_edge_upsert",
+      "seconds": 0.1181,
+      "items": 1485,
+      "per_item_ms": 0.08,
+      "note": "",
+      "points_per_sec": 12578.5
+    },
+    {
+      "stage": "qdrant_edge_has_hash",
+      "seconds": 0.0013,
+      "items": 200,
+      "per_item_ms": 0.007,
+      "note": "",
+      "lookups_per_sec": 151408.9
+    },
+    {
+      "stage": "qdrant_edge_search",
+      "seconds": 0.0049,
+      "items": 14,
+      "per_item_ms": 0.354,
+      "note": "",
+      "queries_per_sec": 2828.8
+    }
+  ],
+  "end_to_end_total_s": 0.32641716899979656
+}

--- a/bench-results/bench_200_post.json
+++ b/bench-results/bench_200_post.json
@@ -4,27 +4,27 @@
   "results": [
     {
       "stage": "walk",
-      "seconds": 0.0209,
+      "seconds": 0.0134,
       "items": 200,
-      "per_item_ms": 0.105,
+      "per_item_ms": 0.067,
       "note": "rglob + is_file filter"
     },
     {
       "stage": "hash_sha256",
-      "seconds": 0.0418,
+      "seconds": 0.0303,
       "items": 200,
-      "per_item_ms": 0.209,
+      "per_item_ms": 0.151,
       "note": "",
-      "mb_per_sec": 23.11,
+      "mb_per_sec": 31.91,
       "total_mb": 0.97
     },
     {
       "stage": "extract_text",
-      "seconds": 0.0311,
+      "seconds": 0.024,
       "items": 200,
-      "per_item_ms": 0.156,
+      "per_item_ms": 0.12,
       "note": "",
-      "mchars_per_sec": 32.53,
+      "mchars_per_sec": 42.15,
       "total_mchars": 1.01
     },
     {
@@ -38,85 +38,85 @@
     },
     {
       "stage": "bm25_tokenize",
-      "seconds": 0.0286,
+      "seconds": 0.0233,
       "items": 1485,
-      "per_item_ms": 0.019,
+      "per_item_ms": 0.016,
       "note": "",
       "total_tokens": 175869,
-      "tokens_per_sec": 6157589.0
+      "tokens_per_sec": 7553445.0
     },
     {
       "stage": "bm25_build_fresh",
-      "seconds": 0.0662,
+      "seconds": 0.0659,
       "items": 1485,
-      "per_item_ms": 0.045,
+      "per_item_ms": 0.044,
       "note": "build_index(all_docs)",
-      "docs_per_sec": 22416.5
+      "docs_per_sec": 22524.5
     },
     {
       "stage": "bm25_incremental_per_file",
-      "seconds": 0.0532,
+      "seconds": 0.0539,
       "items": 200,
-      "per_item_ms": 0.266,
-      "note": "indexer.py path: add_documents() per file (O(n^2))",
+      "per_item_ms": 0.27,
+      "note": "indexer.py path: add_documents() per file + final flush()",
       "total_chunks": 1485,
-      "files_per_sec": 3759.68
+      "files_per_sec": 3709.22
     },
     {
       "stage": "bm25_search",
-      "seconds": 0.0079,
+      "seconds": 0.0081,
       "items": 14,
-      "per_item_ms": 0.567,
+      "per_item_ms": 0.581,
       "note": "",
-      "queries_per_sec": 1762.2
+      "queries_per_sec": 1720.2
     },
     {
       "stage": "embed_batch_1",
-      "seconds": 0.194,
+      "seconds": 0.3723,
       "items": 1485,
-      "per_item_ms": 0.131,
+      "per_item_ms": 0.251,
       "note": "MOCK (not real ML timing)",
-      "chunks_per_sec": 7654.7
+      "chunks_per_sec": 3988.5
     },
     {
       "stage": "embed_batch_8",
-      "seconds": 0.0488,
+      "seconds": 0.0336,
       "items": 1485,
-      "per_item_ms": 0.033,
+      "per_item_ms": 0.023,
       "note": "MOCK (not real ML timing)",
-      "chunks_per_sec": 30448.9
+      "chunks_per_sec": 44153.9
     },
     {
       "stage": "embed_batch_32",
-      "seconds": 0.0527,
+      "seconds": 0.0339,
       "items": 1485,
-      "per_item_ms": 0.035,
+      "per_item_ms": 0.023,
       "note": "MOCK (not real ML timing)",
-      "chunks_per_sec": 28182.5
+      "chunks_per_sec": 43781.4
     },
     {
       "stage": "embed_batch_64",
-      "seconds": 0.049,
+      "seconds": 0.0336,
       "items": 1485,
-      "per_item_ms": 0.033,
+      "per_item_ms": 0.023,
       "note": "MOCK (not real ML timing)",
-      "chunks_per_sec": 30334.9
+      "chunks_per_sec": 44182.4
     },
     {
       "stage": "embed_query",
-      "seconds": 0.0004,
+      "seconds": 0.0003,
       "items": 14,
-      "per_item_ms": 0.031,
+      "per_item_ms": 0.022,
       "note": "MOCK (not real ML timing)",
-      "queries_per_sec": 32174.3
+      "queries_per_sec": 44719.0
     },
     {
       "stage": "qdrant_edge_upsert",
-      "seconds": 0.1181,
+      "seconds": 0.1066,
       "items": 1485,
-      "per_item_ms": 0.08,
+      "per_item_ms": 0.072,
       "note": "",
-      "points_per_sec": 12578.5
+      "points_per_sec": 13927.0
     },
     {
       "stage": "qdrant_edge_has_hash",
@@ -124,16 +124,16 @@
       "items": 200,
       "per_item_ms": 0.007,
       "note": "",
-      "lookups_per_sec": 151408.9
+      "lookups_per_sec": 152647.3
     },
     {
       "stage": "qdrant_edge_search",
-      "seconds": 0.0049,
+      "seconds": 0.0061,
       "items": 14,
-      "per_item_ms": 0.354,
+      "per_item_ms": 0.433,
       "note": "",
-      "queries_per_sec": 2828.8
+      "queries_per_sec": 2310.1
     }
   ],
-  "end_to_end_total_s": 0.32641716899979656
+  "end_to_end_total_s": 0.2707280450000269
 }

--- a/bench-results/bench_500.json
+++ b/bench-results/bench_500.json
@@ -1,0 +1,115 @@
+{
+  "n_files": 500,
+  "n_chunks": 3779,
+  "results": [
+    {
+      "stage": "walk",
+      "seconds": 0.0661,
+      "items": 500,
+      "per_item_ms": 0.132,
+      "note": "rglob + is_file filter"
+    },
+    {
+      "stage": "hash_sha256",
+      "seconds": 0.1197,
+      "items": 500,
+      "per_item_ms": 0.239,
+      "note": "",
+      "mb_per_sec": 20.35,
+      "total_mb": 2.44
+    },
+    {
+      "stage": "extract_text",
+      "seconds": 0.1267,
+      "items": 500,
+      "per_item_ms": 0.253,
+      "note": "",
+      "mchars_per_sec": 20.17,
+      "total_mchars": 2.56
+    },
+    {
+      "stage": "chunk",
+      "seconds": 0.0283,
+      "items": 500,
+      "per_item_ms": 0.057,
+      "note": "",
+      "total_chunks": 3779,
+      "avg_chunks_per_file": 7.56
+    },
+    {
+      "stage": "bm25_tokenize",
+      "seconds": 0.0994,
+      "items": 3779,
+      "per_item_ms": 0.026,
+      "note": "",
+      "total_tokens": 442821,
+      "tokens_per_sec": 4454695.0
+    },
+    {
+      "stage": "bm25_build_fresh",
+      "seconds": 0.2918,
+      "items": 3779,
+      "per_item_ms": 0.077,
+      "note": "build_index(all_docs)",
+      "docs_per_sec": 12948.9
+    },
+    {
+      "stage": "bm25_incremental_per_file",
+      "seconds": 67.6987,
+      "items": 500,
+      "per_item_ms": 135.397,
+      "note": "indexer.py path: add_documents() per file (O(n^2))",
+      "total_chunks": 3779,
+      "files_per_sec": 7.39
+    },
+    {
+      "stage": "bm25_search",
+      "seconds": 0.0723,
+      "items": 14,
+      "per_item_ms": 5.165,
+      "note": "",
+      "queries_per_sec": 193.6
+    },
+    {
+      "stage": "embed_batch_1",
+      "seconds": 0.2046,
+      "items": 3779,
+      "per_item_ms": 0.054,
+      "note": "MOCK (not real ML timing)",
+      "chunks_per_sec": 18466.7
+    },
+    {
+      "stage": "embed_batch_8",
+      "seconds": 0.1802,
+      "items": 3779,
+      "per_item_ms": 0.048,
+      "note": "MOCK (not real ML timing)",
+      "chunks_per_sec": 20966.2
+    },
+    {
+      "stage": "embed_batch_32",
+      "seconds": 0.1802,
+      "items": 3779,
+      "per_item_ms": 0.048,
+      "note": "MOCK (not real ML timing)",
+      "chunks_per_sec": 20973.0
+    },
+    {
+      "stage": "embed_batch_64",
+      "seconds": 0.1753,
+      "items": 3779,
+      "per_item_ms": 0.046,
+      "note": "MOCK (not real ML timing)",
+      "chunks_per_sec": 21555.1
+    },
+    {
+      "stage": "embed_query",
+      "seconds": 0.0007,
+      "items": 14,
+      "per_item_ms": 0.05,
+      "note": "MOCK (not real ML timing)",
+      "queries_per_sec": 19849.1
+    }
+  ],
+  "end_to_end_total_s": 68.21975473300006
+}

--- a/bench-results/bench_500_post.json
+++ b/bench-results/bench_500_post.json
@@ -1,0 +1,115 @@
+{
+  "n_files": 500,
+  "n_chunks": 3779,
+  "results": [
+    {
+      "stage": "walk",
+      "seconds": 0.0487,
+      "items": 500,
+      "per_item_ms": 0.097,
+      "note": "rglob + is_file filter"
+    },
+    {
+      "stage": "hash_sha256",
+      "seconds": 0.0966,
+      "items": 500,
+      "per_item_ms": 0.193,
+      "note": "",
+      "mb_per_sec": 25.23,
+      "total_mb": 2.44
+    },
+    {
+      "stage": "extract_text",
+      "seconds": 0.0817,
+      "items": 500,
+      "per_item_ms": 0.163,
+      "note": "",
+      "mchars_per_sec": 31.28,
+      "total_mchars": 2.56
+    },
+    {
+      "stage": "chunk",
+      "seconds": 0.0225,
+      "items": 500,
+      "per_item_ms": 0.045,
+      "note": "",
+      "total_chunks": 3779,
+      "avg_chunks_per_file": 7.56
+    },
+    {
+      "stage": "bm25_tokenize",
+      "seconds": 0.0631,
+      "items": 3779,
+      "per_item_ms": 0.017,
+      "note": "",
+      "total_tokens": 442821,
+      "tokens_per_sec": 7019468.0
+    },
+    {
+      "stage": "bm25_build_fresh",
+      "seconds": 0.1765,
+      "items": 3779,
+      "per_item_ms": 0.047,
+      "note": "build_index(all_docs)",
+      "docs_per_sec": 21413.6
+    },
+    {
+      "stage": "bm25_incremental_per_file",
+      "seconds": 0.1407,
+      "items": 500,
+      "per_item_ms": 0.281,
+      "note": "indexer.py path: add_documents() per file (O(n^2))",
+      "total_chunks": 3779,
+      "files_per_sec": 3554.81
+    },
+    {
+      "stage": "bm25_search",
+      "seconds": 0.0288,
+      "items": 14,
+      "per_item_ms": 2.056,
+      "note": "",
+      "queries_per_sec": 486.5
+    },
+    {
+      "stage": "embed_batch_1",
+      "seconds": 0.2436,
+      "items": 3779,
+      "per_item_ms": 0.064,
+      "note": "MOCK (not real ML timing)",
+      "chunks_per_sec": 15514.4
+    },
+    {
+      "stage": "embed_batch_8",
+      "seconds": 0.111,
+      "items": 3779,
+      "per_item_ms": 0.029,
+      "note": "MOCK (not real ML timing)",
+      "chunks_per_sec": 34045.1
+    },
+    {
+      "stage": "embed_batch_32",
+      "seconds": 0.1123,
+      "items": 3779,
+      "per_item_ms": 0.03,
+      "note": "MOCK (not real ML timing)",
+      "chunks_per_sec": 33637.3
+    },
+    {
+      "stage": "embed_batch_64",
+      "seconds": 0.1146,
+      "items": 3779,
+      "per_item_ms": 0.03,
+      "note": "MOCK (not real ML timing)",
+      "chunks_per_sec": 32970.5
+    },
+    {
+      "stage": "embed_query",
+      "seconds": 0.0004,
+      "items": 14,
+      "per_item_ms": 0.029,
+      "note": "MOCK (not real ML timing)",
+      "queries_per_sec": 34888.2
+    }
+  ],
+  "end_to_end_total_s": 0.5024720339999931
+}

--- a/bench-results/bench_500_post.json
+++ b/bench-results/bench_500_post.json
@@ -4,112 +4,112 @@
   "results": [
     {
       "stage": "walk",
-      "seconds": 0.0487,
+      "seconds": 0.0324,
       "items": 500,
-      "per_item_ms": 0.097,
+      "per_item_ms": 0.065,
       "note": "rglob + is_file filter"
     },
     {
       "stage": "hash_sha256",
-      "seconds": 0.0966,
+      "seconds": 0.0862,
       "items": 500,
-      "per_item_ms": 0.193,
+      "per_item_ms": 0.172,
       "note": "",
-      "mb_per_sec": 25.23,
+      "mb_per_sec": 28.27,
       "total_mb": 2.44
     },
     {
       "stage": "extract_text",
-      "seconds": 0.0817,
+      "seconds": 0.0732,
       "items": 500,
-      "per_item_ms": 0.163,
+      "per_item_ms": 0.146,
       "note": "",
-      "mchars_per_sec": 31.28,
+      "mchars_per_sec": 34.93,
       "total_mchars": 2.56
     },
     {
       "stage": "chunk",
-      "seconds": 0.0225,
+      "seconds": 0.019,
       "items": 500,
-      "per_item_ms": 0.045,
+      "per_item_ms": 0.038,
       "note": "",
       "total_chunks": 3779,
       "avg_chunks_per_file": 7.56
     },
     {
       "stage": "bm25_tokenize",
-      "seconds": 0.0631,
+      "seconds": 0.0541,
       "items": 3779,
-      "per_item_ms": 0.017,
+      "per_item_ms": 0.014,
       "note": "",
       "total_tokens": 442821,
-      "tokens_per_sec": 7019468.0
+      "tokens_per_sec": 8178670.0
     },
     {
       "stage": "bm25_build_fresh",
-      "seconds": 0.1765,
+      "seconds": 0.1616,
       "items": 3779,
-      "per_item_ms": 0.047,
+      "per_item_ms": 0.043,
       "note": "build_index(all_docs)",
-      "docs_per_sec": 21413.6
+      "docs_per_sec": 23380.5
     },
     {
       "stage": "bm25_incremental_per_file",
-      "seconds": 0.1407,
+      "seconds": 0.1509,
       "items": 500,
-      "per_item_ms": 0.281,
-      "note": "indexer.py path: add_documents() per file (O(n^2))",
+      "per_item_ms": 0.302,
+      "note": "indexer.py path: add_documents() per file + final flush()",
       "total_chunks": 3779,
-      "files_per_sec": 3554.81
+      "files_per_sec": 3312.72
     },
     {
       "stage": "bm25_search",
-      "seconds": 0.0288,
+      "seconds": 0.0317,
       "items": 14,
-      "per_item_ms": 2.056,
+      "per_item_ms": 2.262,
       "note": "",
-      "queries_per_sec": 486.5
+      "queries_per_sec": 442.2
     },
     {
       "stage": "embed_batch_1",
-      "seconds": 0.2436,
+      "seconds": 0.2231,
       "items": 3779,
-      "per_item_ms": 0.064,
+      "per_item_ms": 0.059,
       "note": "MOCK (not real ML timing)",
-      "chunks_per_sec": 15514.4
+      "chunks_per_sec": 16941.1
     },
     {
       "stage": "embed_batch_8",
-      "seconds": 0.111,
+      "seconds": 0.0838,
       "items": 3779,
-      "per_item_ms": 0.029,
+      "per_item_ms": 0.022,
       "note": "MOCK (not real ML timing)",
-      "chunks_per_sec": 34045.1
+      "chunks_per_sec": 45071.0
     },
     {
       "stage": "embed_batch_32",
-      "seconds": 0.1123,
+      "seconds": 0.0832,
       "items": 3779,
-      "per_item_ms": 0.03,
+      "per_item_ms": 0.022,
       "note": "MOCK (not real ML timing)",
-      "chunks_per_sec": 33637.3
+      "chunks_per_sec": 45441.9
     },
     {
       "stage": "embed_batch_64",
-      "seconds": 0.1146,
+      "seconds": 0.0887,
       "items": 3779,
-      "per_item_ms": 0.03,
+      "per_item_ms": 0.023,
       "note": "MOCK (not real ML timing)",
-      "chunks_per_sec": 32970.5
+      "chunks_per_sec": 42624.2
     },
     {
       "stage": "embed_query",
-      "seconds": 0.0004,
+      "seconds": 0.0003,
       "items": 14,
-      "per_item_ms": 0.029,
+      "per_item_ms": 0.024,
       "note": "MOCK (not real ML timing)",
-      "queries_per_sec": 34888.2
+      "queries_per_sec": 41943.3
     }
   ],
-  "end_to_end_total_s": 0.5024720339999931
+  "end_to_end_total_s": 0.44485876800001733
 }

--- a/locallens/_bm25_core.py
+++ b/locallens/_bm25_core.py
@@ -1,0 +1,346 @@
+"""Shared BM25 core — single source of truth for both the CLI and backend.
+
+Both ``locallens/bm25.py`` and ``backend/app/services/bm25.py`` used to carry
+near-identical copies of a ``rank_bm25``-based implementation that rebuilt the
+entire BM25 index and rewrote the full JSON file on every ``add_documents``
+call. For an indexer that calls ``add_documents`` once per file, this is
+O(N^2) in the number of files and dominates wall-clock time (see
+``bench-results/FINDINGS.md``).
+
+This module replaces that with a parameterised ``_Bm25Index`` class that:
+
+* maintains running ``df`` / ``total_tokens`` counters so ``add_documents``
+  and ``remove_documents`` do only per-doc work;
+* stores per-doc term-frequency dicts so scoring never retokenizes;
+* recomputes ``idf`` lazily on first ``search`` after a mutation;
+* defers persistence — writes are marked dirty and batched, with an
+  ``atexit`` hook and an explicit ``flush()`` for graceful shutdown;
+* keeps the on-disk JSON shape identical to the pre-fix format so existing
+  indexes load without migration and downgrades remain safe.
+
+Ranking semantics match ``rank_bm25.BM25Okapi`` exactly: same ``k1=1.5``,
+``b=0.75``, epsilon-smoothed IDF (``epsilon=0.25``).
+
+The module is private (leading underscore) — callers import the thin
+wrappers in ``locallens/bm25.py`` and ``backend/app/services/bm25.py``.
+"""
+
+from __future__ import annotations
+
+import atexit
+import json
+import logging
+import math
+import os
+import re
+import threading
+from collections import Counter
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_TOKEN_RE = re.compile(r"\w+")
+
+
+def _tokenize(text: str) -> list[str]:
+    return _TOKEN_RE.findall(text.lower())
+
+
+@dataclass
+class _DocState:
+    doc_ids: list[str] = field(default_factory=list)
+    id_to_idx: dict[str, int] = field(default_factory=dict)
+    doc_tf: list[dict[str, int]] = field(default_factory=list)  # per-doc term freq
+    doc_lengths: list[int] = field(default_factory=list)
+    corpus_texts: list[str] = field(default_factory=list)
+    df: dict[str, int] = field(default_factory=dict)
+    total_tokens: int = 0
+    idf: dict[str, float] | None = None  # None == dirty, recompute on next search
+
+
+class _Bm25Index:
+    """Incremental BM25 Okapi index backed by a JSON file.
+
+    Single-process, not thread-safe for concurrent writers. A module-level
+    ``threading.Lock`` guards the flush path so the ``atexit`` hook and an
+    explicit ``flush()`` call cannot produce an interleaved partial write.
+    """
+
+    def __init__(
+        self,
+        persist_path: Path,
+        *,
+        k1: float = 1.5,
+        b: float = 0.75,
+        epsilon: float = 0.25,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self._persist_path = Path(persist_path)
+        self.k1 = k1
+        self.b = b
+        self.epsilon = epsilon
+        self._log = logger
+        self._state = _DocState()
+        self._dirty = False
+        self._atexit_registered = False
+        self._save_lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Public API (mirrors the old module-level functions)
+    # ------------------------------------------------------------------
+
+    def build_index(self, documents: list[dict]) -> None:
+        """(Re)build the index from scratch. Eagerly persists."""
+        self._state = _DocState()
+        self._add_internal(documents)
+        self._save_now()
+        self._dirty = False
+        if self._log is not None:
+            self._log.info(
+                "BM25 index built with %d documents", len(self._state.doc_ids)
+            )
+
+    def add_documents(self, documents: list[dict]) -> None:
+        """Append or in-place update documents. Defers write by default."""
+        if not documents:
+            return
+        self._add_internal(documents)
+        self._mark_dirty()
+
+    def remove_documents(self, doc_ids: list[str]) -> None:
+        """Remove documents by id. Defers write by default."""
+        if not doc_ids:
+            return
+        s = self._state
+        id_set = set(doc_ids)
+        keep_idx = [i for i, did in enumerate(s.doc_ids) if did not in id_set]
+        if len(keep_idx) == len(s.doc_ids):
+            return  # nothing to remove
+
+        new_doc_ids: list[str] = []
+        new_doc_tf: list[dict[str, int]] = []
+        new_doc_lengths: list[int] = []
+        new_corpus_texts: list[str] = []
+        new_df: dict[str, int] = {}
+        new_total = 0
+        for i in keep_idx:
+            new_doc_ids.append(s.doc_ids[i])
+            tf = s.doc_tf[i]
+            new_doc_tf.append(tf)
+            new_doc_lengths.append(s.doc_lengths[i])
+            new_corpus_texts.append(s.corpus_texts[i])
+            new_total += s.doc_lengths[i]
+            for term in tf:
+                new_df[term] = new_df.get(term, 0) + 1
+
+        s.doc_ids = new_doc_ids
+        s.doc_tf = new_doc_tf
+        s.doc_lengths = new_doc_lengths
+        s.corpus_texts = new_corpus_texts
+        s.df = new_df
+        s.total_tokens = new_total
+        s.id_to_idx = {did: i for i, did in enumerate(new_doc_ids)}
+        s.idf = None
+        self._mark_dirty()
+
+    def search(self, query: str, top_k: int = 10) -> list[tuple[str, float]]:
+        s = self._state
+        if not s.doc_ids:
+            return []
+        tokens = _tokenize(query)
+        if not tokens:
+            return []
+
+        if s.idf is None:
+            self._recompute_idf()
+        assert s.idf is not None
+        idf = s.idf
+        N = len(s.doc_ids)
+        if N == 0:
+            return []
+        avgdl = s.total_tokens / N if N else 0.0
+        k1 = self.k1
+        b = self.b
+
+        scores = [0.0] * N
+        # Iterate query tokens — rank_bm25 sums per-token contributions, so a
+        # repeated token in the query adds its contribution twice. We match
+        # that behaviour exactly for parity.
+        for qt in tokens:
+            qidf = idf.get(qt, 0.0)
+            if qidf == 0.0:
+                continue
+            for i in range(N):
+                tf = s.doc_tf[i].get(qt)
+                if not tf:
+                    continue
+                dl = s.doc_lengths[i]
+                if avgdl > 0:
+                    denom = tf + k1 * (1 - b + b * dl / avgdl)
+                else:
+                    denom = tf + k1
+                scores[i] += qidf * (tf * (k1 + 1)) / denom
+
+        ranked = sorted(
+            ((i, sc) for i, sc in enumerate(scores) if sc > 0),
+            key=lambda x: x[1],
+            reverse=True,
+        )
+        return [(s.doc_ids[i], float(sc)) for i, sc in ranked[:top_k]]
+
+    def load(self) -> None:
+        """Load persisted index. Tolerates old-format JSON without migration."""
+        if not self._persist_path.exists():
+            return
+        try:
+            data = json.loads(self._persist_path.read_text())
+        except Exception as exc:
+            if self._log is not None:
+                self._log.warning("Could not load BM25 index: %s", exc)
+            return
+
+        doc_ids = [str(x) for x in data.get("doc_ids", [])]
+        corpus_texts = [str(x) for x in data.get("corpus_texts", [])]
+        if len(doc_ids) != len(corpus_texts):
+            if self._log is not None:
+                self._log.warning(
+                    "BM25 index on disk is inconsistent (doc_ids=%d, corpus_texts=%d); "
+                    "ignoring.",
+                    len(doc_ids),
+                    len(corpus_texts),
+                )
+            return
+
+        state = _DocState()
+        for did, txt in zip(doc_ids, corpus_texts):
+            tokens = _tokenize(txt)
+            tf = Counter(tokens)
+            state.doc_ids.append(did)
+            state.id_to_idx[did] = len(state.doc_ids) - 1
+            state.doc_tf.append(dict(tf))
+            state.doc_lengths.append(len(tokens))
+            state.corpus_texts.append(txt)
+            state.total_tokens += len(tokens)
+            for term in tf:
+                state.df[term] = state.df.get(term, 0) + 1
+
+        self._state = state
+        self._dirty = False  # just loaded; disk matches memory
+        if self._log is not None:
+            self._log.info("BM25 index loaded: %d documents", len(state.doc_ids))
+
+    def is_loaded(self) -> bool:
+        return len(self._state.doc_ids) > 0
+
+    def flush(self) -> None:
+        """Persist pending changes. Idempotent; safe to call multiple times."""
+        if not self._dirty:
+            return
+        self._save_now()
+        self._dirty = False
+
+    # ------------------------------------------------------------------
+    # Helpers used by wrapper modules and the bench harness
+    # ------------------------------------------------------------------
+
+    def set_persist_path(self, path: Path) -> None:
+        """Change the on-disk location. Flushes pending writes to the old path
+        first so nothing is lost. Used by tests and the bench harness."""
+        self.flush()
+        self._persist_path = Path(path)
+
+    @property
+    def persist_path(self) -> Path:
+        return self._persist_path
+
+    @property
+    def state(self) -> _DocState:
+        """Expose internal state for tests. Do not mutate from outside."""
+        return self._state
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _add_internal(self, documents: Iterable[dict]) -> None:
+        s = self._state
+        for d in documents:
+            doc_id = str(d["id"])
+            text = d.get("chunk_text", "") or ""
+            tokens = _tokenize(text)
+            tf = dict(Counter(tokens))
+            length = len(tokens)
+
+            existing_idx = s.id_to_idx.get(doc_id)
+            if existing_idx is not None:
+                # Subtract the old contribution before writing the new one.
+                old_tf = s.doc_tf[existing_idx]
+                s.total_tokens -= s.doc_lengths[existing_idx]
+                for term in old_tf:
+                    c = s.df.get(term, 0) - 1
+                    if c <= 0:
+                        s.df.pop(term, None)
+                    else:
+                        s.df[term] = c
+                s.doc_tf[existing_idx] = tf
+                s.doc_lengths[existing_idx] = length
+                s.corpus_texts[existing_idx] = text
+            else:
+                s.id_to_idx[doc_id] = len(s.doc_ids)
+                s.doc_ids.append(doc_id)
+                s.doc_tf.append(tf)
+                s.doc_lengths.append(length)
+                s.corpus_texts.append(text)
+
+            s.total_tokens += length
+            for term in tf:
+                s.df[term] = s.df.get(term, 0) + 1
+
+        s.idf = None  # mark dirty
+
+    def _recompute_idf(self) -> None:
+        s = self._state
+        N = len(s.doc_ids)
+        if N == 0:
+            s.idf = {}
+            return
+        # rank_bm25 BM25Okapi formula, with epsilon smoothing.
+        raw: dict[str, float] = {}
+        neg_terms: list[str] = []
+        idf_sum = 0.0
+        for term, df_t in s.df.items():
+            val = math.log((N - df_t + 0.5) / (df_t + 0.5))
+            raw[term] = val
+            idf_sum += val
+            if val < 0:
+                neg_terms.append(term)
+        avg_idf = idf_sum / len(raw) if raw else 0.0
+        floor = self.epsilon * avg_idf
+        for term in neg_terms:
+            raw[term] = floor
+        s.idf = raw
+
+    def _mark_dirty(self) -> None:
+        self._dirty = True
+        if _eager_flush_env():
+            self._save_now()
+            self._dirty = False
+            return
+        if not self._atexit_registered:
+            atexit.register(self.flush)
+            self._atexit_registered = True
+
+    def _save_now(self) -> None:
+        s = self._state
+        with self._save_lock:
+            self._persist_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self._persist_path.with_suffix(self._persist_path.suffix + ".tmp")
+            payload = {"doc_ids": s.doc_ids, "corpus_texts": s.corpus_texts}
+            tmp.write_text(json.dumps(payload))
+            os.replace(tmp, self._persist_path)
+
+
+def _eager_flush_env() -> bool:
+    """Env escape hatch for debugging — persist on every mutation."""
+    val = os.environ.get("LOCALLENS_BM25_EAGER_FLUSH", "").strip().lower()
+    return val in ("1", "true", "yes", "on")

--- a/locallens/_bm25_core.py
+++ b/locallens/_bm25_core.py
@@ -108,38 +108,42 @@ class _Bm25Index:
         self._mark_dirty()
 
     def remove_documents(self, doc_ids: list[str]) -> None:
-        """Remove documents by id. Defers write by default."""
+        """Remove documents by id. Defers write by default.
+
+        In-place decrement: subtract each removed doc's contribution from
+        ``df`` and ``total_tokens`` directly, rather than rebuilding from
+        the surviving docs. Cost is O(removed * avg_terms) for counters
+        plus O(N_total) for the array compaction — strictly cheaper than
+        the previous rebuild when removing a small number from a large
+        corpus, and no worse otherwise.
+        """
         if not doc_ids:
             return
         s = self._state
         id_set = set(doc_ids)
-        keep_idx = [i for i, did in enumerate(s.doc_ids) if did not in id_set]
-        if len(keep_idx) == len(s.doc_ids):
-            return  # nothing to remove
+        drop_idx = [i for i, did in enumerate(s.doc_ids) if did in id_set]
+        if not drop_idx:
+            return
 
-        new_doc_ids: list[str] = []
-        new_doc_tf: list[dict[str, int]] = []
-        new_doc_lengths: list[int] = []
-        new_corpus_texts: list[str] = []
-        new_df: dict[str, int] = {}
-        new_total = 0
-        for i in keep_idx:
-            new_doc_ids.append(s.doc_ids[i])
-            tf = s.doc_tf[i]
-            new_doc_tf.append(tf)
-            new_doc_lengths.append(s.doc_lengths[i])
-            new_corpus_texts.append(s.corpus_texts[i])
-            new_total += s.doc_lengths[i]
-            for term in tf:
-                new_df[term] = new_df.get(term, 0) + 1
+        # Subtract the removed docs' contributions to df / total_tokens.
+        for i in drop_idx:
+            s.total_tokens -= s.doc_lengths[i]
+            for term in s.doc_tf[i]:
+                c = s.df.get(term, 0) - 1
+                if c <= 0:
+                    s.df.pop(term, None)
+                else:
+                    s.df[term] = c
 
-        s.doc_ids = new_doc_ids
-        s.doc_tf = new_doc_tf
-        s.doc_lengths = new_doc_lengths
-        s.corpus_texts = new_corpus_texts
-        s.df = new_df
-        s.total_tokens = new_total
-        s.id_to_idx = {did: i for i, did in enumerate(new_doc_ids)}
+        # Compact the parallel arrays. Python lists don't support
+        # mid-delete cheaply, so we rebuild the surviving slices in one
+        # pass using a single set membership check.
+        drop_set = set(drop_idx)
+        s.doc_ids = [v for i, v in enumerate(s.doc_ids) if i not in drop_set]
+        s.doc_tf = [v for i, v in enumerate(s.doc_tf) if i not in drop_set]
+        s.doc_lengths = [v for i, v in enumerate(s.doc_lengths) if i not in drop_set]
+        s.corpus_texts = [v for i, v in enumerate(s.corpus_texts) if i not in drop_set]
+        s.id_to_idx = {did: i for i, did in enumerate(s.doc_ids)}
         s.idf = None
         self._mark_dirty()
 
@@ -155,10 +159,8 @@ class _Bm25Index:
             self._recompute_idf()
         assert s.idf is not None
         idf = s.idf
-        N = len(s.doc_ids)
-        if N == 0:
-            return []
-        avgdl = s.total_tokens / N if N else 0.0
+        N = len(s.doc_ids)  # > 0 — checked above via ``if not s.doc_ids``
+        avgdl = s.total_tokens / N
         k1 = self.k1
         b = self.b
 

--- a/locallens/bm25.py
+++ b/locallens/bm25.py
@@ -34,4 +34,4 @@ def _set_persist_path(path: Path) -> None:
     Used by tests and ``scripts/bench_pipeline.py`` to point the singleton at
     an isolated directory so benchmarks don't touch the user's real index.
     """
-    _index.set_persist_path(Path(path))
+    _index.set_persist_path(path)

--- a/locallens/bm25.py
+++ b/locallens/bm25.py
@@ -1,95 +1,37 @@
 """BM25 keyword index for hybrid search (CLI side).
 
-Maintains an in-memory BM25 index persisted at ~/.locallens/bm25_index.json.
+Thin wrapper around ``locallens._bm25_core._Bm25Index``. The module-level
+API is preserved for callers: ``build_index``, ``add_documents``,
+``remove_documents``, ``search``, ``load``, ``is_loaded``, plus ``flush``.
+
+Persists to ``~/.locallens/bm25_index.json`` by default.
 """
 
-import json
-import re
+from __future__ import annotations
+
 from pathlib import Path
 
-from rank_bm25 import BM25Okapi
+from locallens._bm25_core import _Bm25Index
 
 _BM25_PATH = Path.home() / ".locallens" / "bm25_index.json"
 
-_bm25: BM25Okapi | None = None
-_doc_ids: list[str] = []
-_corpus_texts: list[str] = []
+_index = _Bm25Index(_BM25_PATH)
+
+# Module-level re-exports so existing callers (``bm25.add_documents(...)``)
+# keep working without change.
+build_index = _index.build_index
+add_documents = _index.add_documents
+remove_documents = _index.remove_documents
+search = _index.search
+load = _index.load
+is_loaded = _index.is_loaded
+flush = _index.flush
 
 
-def _tokenize(text: str) -> list[str]:
-    return re.findall(r"\w+", text.lower())
+def _set_persist_path(path: Path) -> None:
+    """Redirect the underlying index to a new on-disk path.
 
-
-def build_index(documents: list[dict]) -> None:
-    global _bm25, _doc_ids, _corpus_texts
-    _doc_ids = [str(d["id"]) for d in documents]
-    _corpus_texts = [d.get("chunk_text", "") for d in documents]
-    tokenized = [_tokenize(t) for t in _corpus_texts]
-    _bm25 = BM25Okapi(tokenized) if tokenized else None
-    _save()
-
-
-def add_documents(documents: list[dict]) -> None:
-    global _bm25, _doc_ids, _corpus_texts
-    for d in documents:
-        doc_id = str(d["id"])
-        if doc_id in _doc_ids:
-            idx = _doc_ids.index(doc_id)
-            _corpus_texts[idx] = d.get("chunk_text", "")
-        else:
-            _doc_ids.append(doc_id)
-            _corpus_texts.append(d.get("chunk_text", ""))
-    tokenized = [_tokenize(t) for t in _corpus_texts]
-    _bm25 = BM25Okapi(tokenized) if tokenized else None
-    _save()
-
-
-def remove_documents(doc_ids: list[str]) -> None:
-    global _bm25, _doc_ids, _corpus_texts
-    id_set = set(doc_ids)
-    pairs = [
-        (did, txt) for did, txt in zip(_doc_ids, _corpus_texts) if did not in id_set
-    ]
-    if pairs:
-        _doc_ids, _corpus_texts = map(list, zip(*pairs))
-    else:
-        _doc_ids, _corpus_texts = [], []
-    tokenized = [_tokenize(t) for t in _corpus_texts]
-    _bm25 = BM25Okapi(tokenized) if tokenized else None
-    _save()
-
-
-def search(query: str, top_k: int = 10) -> list[tuple[str, float]]:
-    if _bm25 is None or not _doc_ids:
-        return []
-    tokens = _tokenize(query)
-    if not tokens:
-        return []
-    scores = _bm25.get_scores(tokens)
-    ranked = sorted(enumerate(scores), key=lambda x: x[1], reverse=True)
-    return [(_doc_ids[idx], float(score)) for idx, score in ranked[:top_k] if score > 0]
-
-
-def load() -> None:
-    global _bm25, _doc_ids, _corpus_texts
-    if not _BM25_PATH.exists():
-        return
-    try:
-        data = json.loads(_BM25_PATH.read_text())
-        _doc_ids = data.get("doc_ids", [])
-        _corpus_texts = data.get("corpus_texts", [])
-        tokenized = [_tokenize(t) for t in _corpus_texts]
-        _bm25 = BM25Okapi(tokenized) if tokenized else None
-    except Exception:
-        pass
-
-
-def _save() -> None:
-    _BM25_PATH.parent.mkdir(parents=True, exist_ok=True)
-    _BM25_PATH.write_text(
-        json.dumps({"doc_ids": _doc_ids, "corpus_texts": _corpus_texts})
-    )
-
-
-def is_loaded() -> bool:
-    return _bm25 is not None and len(_doc_ids) > 0
+    Used by tests and ``scripts/bench_pipeline.py`` to point the singleton at
+    an isolated directory so benchmarks don't touch the user's real index.
+    """
+    _index.set_persist_path(Path(path))

--- a/locallens/indexer.py
+++ b/locallens/indexer.py
@@ -226,6 +226,8 @@ def index_folder(folder: Path, force: bool = False) -> None:
 
             progress.advance(task)
 
+    bm25.flush()
+
     elapsed = time.time() - start
     console.print(
         f"\n[green]Indexed {indexed_files} files ({total_chunks} chunks) "

--- a/scripts/bench_pipeline.py
+++ b/scripts/bench_pipeline.py
@@ -293,20 +293,23 @@ def bench_bm25_build_fresh(chunks_all: list[list[str]], paths: list[Path]) -> St
 
 
 def bench_bm25_incremental(chunks_all: list[list[str]], paths: list[Path]) -> StageResult:
-    # Simulate what indexer.py does: call add_documents once per file.
-    # Reset state, then add file-by-file.
+    # Simulate what indexer.py does: call add_documents once per file, then
+    # flush at the end (matches locallens/indexer.py and backend lifespan).
+    # The pre-fix path persisted on every add_documents call, so for a
+    # like-for-like comparison the post-fix measurement must include flush.
     bm25_mod.build_index([])
     t0 = time.perf_counter()
     for p, cs in zip(paths, chunks_all):
         docs = [{"id": f"{p}:{i}", "chunk_text": c} for i, c in enumerate(cs)]
         bm25_mod.add_documents(docs)
+    bm25_mod.flush()
     dt = time.perf_counter() - t0
     total_chunks = sum(len(c) for c in chunks_all)
     return StageResult(
         "bm25_incremental_per_file",
         dt,
         len(paths),
-        note="indexer.py path: add_documents() per file (O(n^2))",
+        note="indexer.py path: add_documents() per file + final flush()",
         extra={
             "total_chunks": total_chunks,
             "files_per_sec": round(len(paths) / dt, 2) if dt else 0.0,

--- a/scripts/bench_pipeline.py
+++ b/scripts/bench_pipeline.py
@@ -480,8 +480,7 @@ def main() -> None:
     # Point the store & bm25 at an isolated path so we don't touch user data.
     bench_lens_home = Path(tmp_root) / "locallens_home"
     bench_lens_home.mkdir(parents=True, exist_ok=True)
-    # bm25 uses ~/.locallens/bm25_index.json — override the module constant.
-    bm25_mod._BM25_PATH = bench_lens_home / "bm25_index.json"
+    bm25_mod._set_persist_path(bench_lens_home / "bm25_index.json")
     # store uses locallens.config.QDRANT_PATH — override via the store module.
     from locallens import config as cfg
     cfg.QDRANT_PATH = bench_lens_home / "qdrant_data"

--- a/scripts/bench_pipeline.py
+++ b/scripts/bench_pipeline.py
@@ -1,0 +1,606 @@
+"""Benchmark the LocalLens indexing + search pipeline, stage by stage.
+
+Generates a synthetic corpus, then times each hot path independently so we can
+see where wall-clock time is actually spent before considering Rust rewrites.
+
+Run:
+    uv run python scripts/bench_pipeline.py [--files N] [--out report.json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import random
+import statistics
+import tempfile
+import time
+import tracemalloc
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+
+os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+os.environ.setdefault("TRANSFORMERS_VERBOSITY", "error")
+
+from locallens import bm25 as bm25_mod
+from locallens import store as store_mod
+from locallens.chunker import chunk_text
+
+try:
+    from locallens.embedder import embed_query, embed_texts  # noqa: F401
+    _EMBEDDER_AVAILABLE = True
+except Exception:
+    _EMBEDDER_AVAILABLE = False
+
+
+def _mock_embed_texts(texts):
+    """Deterministic 384-dim vectors derived from sha1(text) bytes.
+
+    Not a real embedding — just the right *shape* so we can bench the
+    non-ML stages (upsert, search, bm25) without needing HF access.
+    """
+    import numpy as np
+    out = []
+    for t in texts:
+        h = hashlib.sha1(t.encode("utf-8", errors="ignore")).digest()
+        # Tile the 20-byte digest to 384 floats, normalize to unit length.
+        rng = np.random.default_rng(int.from_bytes(h[:8], "big"))
+        v = rng.standard_normal(384, dtype=np.float32)
+        v /= (np.linalg.norm(v) + 1e-12)
+        out.append(v.tolist())
+    return out
+
+
+def _mock_embed_query(text):
+    return _mock_embed_texts([text])[0]
+
+
+# ----------------------------------------------------------------------------
+# Synthetic corpus generation
+# ----------------------------------------------------------------------------
+
+LOREM = (
+    "the quick brown fox jumps over the lazy dog pack my box with five dozen "
+    "liquor jugs sphinx of black quartz judge my vow how vexingly quick daft "
+    "zebras jump bright vixens jump dozy fowl quack amazingly few discotheques "
+    "provide jukeboxes waltz nymph for quick jigs vex bud jackdaws love my big "
+    "sphinx of quartz the five boxing wizards jump quickly "
+)
+
+TOPICS = [
+    "machine learning", "database indexing", "vector search", "rust programming",
+    "python performance", "distributed systems", "offline-first apps",
+    "tokenization", "embedding models", "BM25 ranking", "compiler design",
+    "semantic retrieval", "chunk overlap", "cosine similarity",
+]
+
+
+def _paragraph(rng: random.Random, size: int) -> str:
+    """Build a paragraph roughly `size` chars long, seeded with topic words."""
+    words: list[str] = []
+    total = 0
+    topic = rng.choice(TOPICS)
+    while total < size:
+        w = rng.choice(LOREM.split())
+        if rng.random() < 0.05:
+            w = topic.split()[rng.randrange(len(topic.split()))]
+        words.append(w)
+        total += len(w) + 1
+    return " ".join(words) + "."
+
+
+def make_markdown(rng: random.Random, sections: int = 6, para_size: int = 400) -> str:
+    out: list[str] = []
+    for i in range(sections):
+        out.append(f"# Section {i + 1}: {rng.choice(TOPICS).title()}")
+        for _ in range(rng.randint(2, 4)):
+            out.append(_paragraph(rng, para_size))
+            out.append("")
+    return "\n".join(out)
+
+
+def make_python(rng: random.Random, n_funcs: int = 8) -> str:
+    lines: list[str] = []
+    for i in range(n_funcs):
+        name = f"compute_{rng.choice(TOPICS).replace(' ', '_')}_{i}"
+        lines.append(f"def {name}(x, y):")
+        lines.append(f'    """{_paragraph(rng, 120)}"""')
+        lines.append("    total = 0")
+        for _ in range(rng.randint(4, 10)):
+            lines.append(f"    total += x * {rng.randint(1, 99)} + y")
+        lines.append("    return total")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def make_plain_text(rng: random.Random, paragraphs: int = 5, para_size: int = 600) -> str:
+    return "\n\n".join(_paragraph(rng, para_size) for _ in range(paragraphs))
+
+
+def generate_corpus(root: Path, n_files: int, rng: random.Random) -> list[Path]:
+    root.mkdir(parents=True, exist_ok=True)
+    paths: list[Path] = []
+    for i in range(n_files):
+        kind = rng.choices(["md", "txt", "py"], weights=[0.5, 0.3, 0.2])[0]
+        if kind == "md":
+            content = make_markdown(rng, sections=rng.randint(3, 8))
+            path = root / f"doc_{i:04d}.md"
+        elif kind == "txt":
+            content = make_plain_text(rng, paragraphs=rng.randint(3, 8))
+            path = root / f"note_{i:04d}.txt"
+        else:
+            content = make_python(rng, n_funcs=rng.randint(4, 12))
+            path = root / f"mod_{i:04d}.py"
+        path.write_text(content, encoding="utf-8")
+        paths.append(path)
+    return paths
+
+
+# ----------------------------------------------------------------------------
+# Benchmark primitives
+# ----------------------------------------------------------------------------
+
+
+@dataclass
+class StageResult:
+    stage: str
+    seconds: float
+    items: int
+    note: str = ""
+    extra: dict = field(default_factory=dict)
+
+    @property
+    def per_item_ms(self) -> float:
+        return (self.seconds / self.items * 1000.0) if self.items else 0.0
+
+    def row(self) -> dict:
+        return {
+            "stage": self.stage,
+            "seconds": round(self.seconds, 4),
+            "items": self.items,
+            "per_item_ms": round(self.per_item_ms, 3),
+            "note": self.note,
+            **self.extra,
+        }
+
+
+def time_it(fn, *args, **kwargs) -> tuple[float, object]:
+    t0 = time.perf_counter()
+    out = fn(*args, **kwargs)
+    return time.perf_counter() - t0, out
+
+
+# ----------------------------------------------------------------------------
+# Stage benchmarks
+# ----------------------------------------------------------------------------
+
+
+def bench_walk(root: Path) -> StageResult:
+    t0 = time.perf_counter()
+    files = [p for p in root.rglob("*") if p.is_file()]
+    dt = time.perf_counter() - t0
+    return StageResult("walk", dt, len(files), note="rglob + is_file filter")
+
+
+def bench_hash(paths: list[Path]) -> StageResult:
+    t0 = time.perf_counter()
+    total_bytes = 0
+    for p in paths:
+        h = hashlib.sha256()
+        with open(p, "rb") as f:
+            for block in iter(lambda: f.read(8192), b""):
+                h.update(block)
+                total_bytes += len(block)
+        h.hexdigest()
+    dt = time.perf_counter() - t0
+    return StageResult(
+        "hash_sha256",
+        dt,
+        len(paths),
+        extra={"mb_per_sec": round(total_bytes / 1024 / 1024 / dt, 2) if dt else 0.0, "total_mb": round(total_bytes / 1024 / 1024, 2)},
+    )
+
+
+def bench_extract(paths: list[Path]) -> tuple[StageResult, list[str]]:
+    # Just use plain read for .md/.txt/.py (matches TextExtractor/CodeExtractor).
+    texts: list[str] = []
+    t0 = time.perf_counter()
+    for p in paths:
+        texts.append(p.read_text(encoding="utf-8", errors="ignore"))
+    dt = time.perf_counter() - t0
+    total_chars = sum(len(t) for t in texts)
+    return StageResult(
+        "extract_text",
+        dt,
+        len(paths),
+        extra={"mchars_per_sec": round(total_chars / 1_000_000 / dt, 2) if dt else 0.0, "total_mchars": round(total_chars / 1_000_000, 2)},
+    ), texts
+
+
+def bench_chunk(paths: list[Path], texts: list[str]) -> tuple[StageResult, list[list[str]]]:
+    chunks_all: list[list[str]] = []
+    t0 = time.perf_counter()
+    for p, txt in zip(paths, texts):
+        chunks_all.append(chunk_text(txt, 1000, 50, file_type=p.suffix.lower()))
+    dt = time.perf_counter() - t0
+    n_chunks = sum(len(c) for c in chunks_all)
+    return StageResult(
+        "chunk",
+        dt,
+        len(paths),
+        extra={"total_chunks": n_chunks, "avg_chunks_per_file": round(n_chunks / max(len(paths), 1), 2)},
+    ), chunks_all
+
+
+def bench_embed_cold(sample_chunks: list[str]) -> StageResult:
+    # Cold start: first call loads the model.
+    t0 = time.perf_counter()
+    embed_texts(sample_chunks[:1])
+    dt = time.perf_counter() - t0
+    return StageResult("embed_model_load_+_1chunk", dt, 1, note="first call, loads model")
+
+
+def bench_embed_batched(chunks_all: list[list[str]], batch_size: int) -> StageResult:
+    flat = [c for cs in chunks_all for c in cs]
+    t0 = time.perf_counter()
+    for i in range(0, len(flat), batch_size):
+        embed_texts(flat[i : i + batch_size])
+    dt = time.perf_counter() - t0
+    return StageResult(
+        f"embed_batch_{batch_size}",
+        dt,
+        len(flat),
+        note="warm model",
+        extra={"chunks_per_sec": round(len(flat) / dt, 1) if dt else 0.0},
+    )
+
+
+def bench_embed_query(n: int = 20) -> StageResult:
+    queries = [f"what is {t}" for t in TOPICS[:n]]
+    # warm-up
+    embed_query("warmup")
+    t0 = time.perf_counter()
+    for q in queries:
+        embed_query(q)
+    dt = time.perf_counter() - t0
+    return StageResult(
+        "embed_query",
+        dt,
+        len(queries),
+        extra={"queries_per_sec": round(len(queries) / dt, 1) if dt else 0.0},
+    )
+
+
+def bench_bm25_build_fresh(chunks_all: list[list[str]], paths: list[Path]) -> StageResult:
+    # Fresh build: all docs at once (what build_index does).
+    docs: list[dict] = []
+    for p, cs in zip(paths, chunks_all):
+        for i, c in enumerate(cs):
+            docs.append({"id": f"{p}:{i}", "chunk_text": c})
+    t0 = time.perf_counter()
+    bm25_mod.build_index(docs)
+    dt = time.perf_counter() - t0
+    return StageResult(
+        "bm25_build_fresh",
+        dt,
+        len(docs),
+        note="build_index(all_docs)",
+        extra={"docs_per_sec": round(len(docs) / dt, 1) if dt else 0.0},
+    )
+
+
+def bench_bm25_incremental(chunks_all: list[list[str]], paths: list[Path]) -> StageResult:
+    # Simulate what indexer.py does: call add_documents once per file.
+    # Reset state, then add file-by-file.
+    bm25_mod.build_index([])
+    t0 = time.perf_counter()
+    for p, cs in zip(paths, chunks_all):
+        docs = [{"id": f"{p}:{i}", "chunk_text": c} for i, c in enumerate(cs)]
+        bm25_mod.add_documents(docs)
+    dt = time.perf_counter() - t0
+    total_chunks = sum(len(c) for c in chunks_all)
+    return StageResult(
+        "bm25_incremental_per_file",
+        dt,
+        len(paths),
+        note="indexer.py path: add_documents() per file (O(n^2))",
+        extra={
+            "total_chunks": total_chunks,
+            "files_per_sec": round(len(paths) / dt, 2) if dt else 0.0,
+        },
+    )
+
+
+def bench_bm25_search(queries: list[str], top_k: int = 10) -> StageResult:
+    t0 = time.perf_counter()
+    for q in queries:
+        bm25_mod.search(q, top_k=top_k)
+    dt = time.perf_counter() - t0
+    return StageResult(
+        "bm25_search",
+        dt,
+        len(queries),
+        extra={"queries_per_sec": round(len(queries) / dt, 1) if dt else 0.0},
+    )
+
+
+def bench_bm25_tokenize(chunks_all: list[list[str]]) -> StageResult:
+    import re
+    flat = [c for cs in chunks_all for c in cs]
+    tok_re = re.compile(r"\w+")
+    t0 = time.perf_counter()
+    total_tokens = 0
+    for c in flat:
+        total_tokens += len(tok_re.findall(c.lower()))
+    dt = time.perf_counter() - t0
+    return StageResult(
+        "bm25_tokenize",
+        dt,
+        len(flat),
+        extra={
+            "total_tokens": total_tokens,
+            "tokens_per_sec": round(total_tokens / dt, 0) if dt else 0.0,
+        },
+    )
+
+
+def bench_store_upsert(chunks_all: list[list[str]], paths: list[Path], embeddings: list[list[float]]) -> StageResult:
+    # Build points shaped like indexer.py does.
+    from locallens.indexer import UUID_NAMESPACE
+    store_mod.init()
+
+    def _point_id(path: str, i: int) -> str:
+        return str(uuid.uuid5(UUID_NAMESPACE, f"{path}:{i}"))
+
+    all_points: list[dict] = []
+    emb_iter = iter(embeddings)
+    for p, cs in zip(paths, chunks_all):
+        abs_p = str(p.resolve())
+        for i, c in enumerate(cs):
+            emb = next(emb_iter)
+            all_points.append(
+                {
+                    "id": _point_id(abs_p, i),
+                    "vector": list(emb),
+                    "payload": {
+                        "file_path": abs_p,
+                        "file_name": p.name,
+                        "file_type": p.suffix.lower(),
+                        "chunk_index": i,
+                        "chunk_text": c,
+                        "file_hash": "bench",
+                        "indexed_at": "2026-01-01T00:00:00+00:00",
+                        "extractor": "bench",
+                        "page_number": None,
+                        "file_modified_at": None,
+                    },
+                }
+            )
+    t0 = time.perf_counter()
+    store_mod.upsert_batch(all_points)
+    dt = time.perf_counter() - t0
+    return StageResult(
+        "qdrant_edge_upsert",
+        dt,
+        len(all_points),
+        extra={"points_per_sec": round(len(all_points) / dt, 1) if dt else 0.0},
+    )
+
+
+def bench_store_has_hash(paths: list[Path]) -> StageResult:
+    # Measure the per-file dedup lookup (O(1) payload-index check).
+    h = hashlib.sha256(b"nonexistent-bench").hexdigest()
+    t0 = time.perf_counter()
+    for _ in paths:
+        store_mod.has_hash(h)
+    dt = time.perf_counter() - t0
+    return StageResult(
+        "qdrant_edge_has_hash",
+        dt,
+        len(paths),
+        extra={"lookups_per_sec": round(len(paths) / dt, 1) if dt else 0.0},
+    )
+
+
+def bench_store_search(queries_vec: list[list[float]], top_k: int = 10) -> StageResult:
+    t0 = time.perf_counter()
+    for v in queries_vec:
+        store_mod.search(v, top_k=top_k)
+    dt = time.perf_counter() - t0
+    return StageResult(
+        "qdrant_edge_search",
+        dt,
+        len(queries_vec),
+        extra={"queries_per_sec": round(len(queries_vec) / dt, 1) if dt else 0.0},
+    )
+
+
+# ----------------------------------------------------------------------------
+# Runner
+# ----------------------------------------------------------------------------
+
+
+def human_seconds(s: float) -> str:
+    if s < 1e-3:
+        return f"{s*1e6:.1f} µs"
+    if s < 1.0:
+        return f"{s*1000:.1f} ms"
+    return f"{s:.2f} s"
+
+
+def print_table(results: list[StageResult]) -> None:
+    print()
+    print(f"{'stage':<35} {'time':>10} {'items':>8} {'per-item':>12}   extra")
+    print("-" * 110)
+    for r in results:
+        extras = " ".join(f"{k}={v}" for k, v in r.extra.items())
+        print(
+            f"{r.stage:<35} {human_seconds(r.seconds):>10} {r.items:>8d} "
+            f"{r.per_item_ms:>10.3f} ms   {extras}"
+        )
+    print()
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--files", type=int, default=200, help="synthetic file count")
+    ap.add_argument("--out", type=str, default=None, help="optional JSON report path")
+    ap.add_argument("--corpus", type=str, default=None, help="reuse existing corpus dir")
+    ap.add_argument("--skip-store", action="store_true", help="skip Qdrant Edge stages")
+    ap.add_argument("--skip-embed", action="store_true", help="skip embedding stages")
+    ap.add_argument(
+        "--mock-embed",
+        action="store_true",
+        help="use deterministic fake 384-dim vectors (for bench only, no ML)",
+    )
+    args = ap.parse_args()
+
+    # Patch in a mock embedder when requested (or when the real one is unavailable).
+    if args.mock_embed or not _EMBEDDER_AVAILABLE:
+        globals()["embed_texts"] = _mock_embed_texts
+        globals()["embed_query"] = _mock_embed_query
+        args.mock_embed = True
+        print("[embed] using MOCK embedder (384-dim vectors derived from sha1)")
+
+    rng = random.Random(42)
+
+    tmp_root = tempfile.mkdtemp(prefix="locallens_bench_")
+    if args.corpus:
+        corpus = Path(args.corpus)
+        paths = sorted(p for p in corpus.rglob("*") if p.is_file())
+        print(f"[corpus] reusing {corpus} with {len(paths)} files")
+    else:
+        corpus = Path(tmp_root) / "corpus"
+        print(f"[corpus] generating {args.files} files in {corpus}")
+        paths = generate_corpus(corpus, args.files, rng)
+
+    # Point the store & bm25 at an isolated path so we don't touch user data.
+    bench_lens_home = Path(tmp_root) / "locallens_home"
+    bench_lens_home.mkdir(parents=True, exist_ok=True)
+    # bm25 uses ~/.locallens/bm25_index.json — override the module constant.
+    bm25_mod._BM25_PATH = bench_lens_home / "bm25_index.json"
+    # store uses locallens.config.QDRANT_PATH — override via the store module.
+    from locallens import config as cfg
+    cfg.QDRANT_PATH = bench_lens_home / "qdrant_data"
+    store_mod.QDRANT_PATH = cfg.QDRANT_PATH
+    # Force shard reset.
+    store_mod._shard = None
+
+    results: list[StageResult] = []
+
+    # 1. walk
+    results.append(bench_walk(corpus))
+
+    # 2. hash
+    results.append(bench_hash(paths))
+
+    # 3. extract (plain read for .md/.txt/.py)
+    extract_result, texts = bench_extract(paths)
+    results.append(extract_result)
+
+    # 4. chunk
+    chunk_result, chunks_all = bench_chunk(paths, texts)
+    results.append(chunk_result)
+
+    flat_chunks = [c for cs in chunks_all for c in cs]
+    print(f"[chunks] total chunks: {len(flat_chunks)}")
+
+    # 5. BM25 tokenize alone
+    results.append(bench_bm25_tokenize(chunks_all))
+
+    # 6. BM25 fresh build
+    results.append(bench_bm25_build_fresh(chunks_all, paths))
+
+    # 7. BM25 incremental (indexer.py path — the O(n^2) problem)
+    results.append(bench_bm25_incremental(chunks_all, paths))
+
+    # 8. BM25 search
+    queries = [f"what is {t}" for t in TOPICS]
+    results.append(bench_bm25_search(queries))
+
+    embeddings: list[list[float]] = []
+
+    if not args.skip_embed:
+        if not args.mock_embed:
+            # 9. embedding cold start (only meaningful for the real model)
+            results.append(bench_embed_cold(flat_chunks))
+
+        # 10. embedding warm, batched
+        for bs in (1, 8, 32, 64):
+            r = bench_embed_batched(chunks_all, batch_size=bs)
+            if args.mock_embed:
+                r.note = "MOCK (not real ML timing)"
+            results.append(r)
+
+        # 11. query embedding (single)
+        r = bench_embed_query(n=len(TOPICS))
+        if args.mock_embed:
+            r.note = "MOCK (not real ML timing)"
+        results.append(r)
+
+        # precompute embeddings for store tests (batch 32 is the natural size)
+        print("[precompute] embedding all chunks (batch=32) for store benches…")
+        t0 = time.perf_counter()
+        for i in range(0, len(flat_chunks), 32):
+            embeddings.extend(embed_texts(flat_chunks[i : i + 32]))
+        print(f"[precompute] done in {time.perf_counter() - t0:.2f}s")
+
+    if not args.skip_store and embeddings:
+        # 12. qdrant edge upsert (single large batch)
+        results.append(bench_store_upsert(chunks_all, paths, embeddings))
+
+        # 13. qdrant edge has_hash
+        results.append(bench_store_has_hash(paths))
+
+        # 14. qdrant edge search
+        qvecs = []
+        for t in TOPICS:
+            qvecs.append(embed_query(f"what is {t}"))
+        results.append(bench_store_search(qvecs))
+
+    print_table(results)
+
+    # Summary: stage share of an end-to-end index run.
+    # Approximate full pipeline = walk + hash + extract + chunk + bm25_incremental + embed_batch_32 + qdrant_upsert.
+    stage_map = {r.stage: r for r in results}
+    end_to_end_stages = [
+        "walk",
+        "hash_sha256",
+        "extract_text",
+        "chunk",
+        "bm25_incremental_per_file",
+        "embed_batch_32",
+        "qdrant_edge_upsert",
+    ]
+    total = sum(stage_map[s].seconds for s in end_to_end_stages if s in stage_map)
+    print(f"End-to-end index (sum of stages): {total:.2f}s for {len(paths)} files, {len(flat_chunks)} chunks")
+    print(f"{'stage':<35} {'seconds':>10} {'share':>8}")
+    print("-" * 60)
+    for s in end_to_end_stages:
+        r = stage_map.get(s)
+        if not r:
+            continue
+        share = (r.seconds / total * 100.0) if total else 0.0
+        print(f"{s:<35} {r.seconds:>10.3f} {share:>7.1f}%")
+    print()
+
+    if args.out:
+        Path(args.out).write_text(
+            json.dumps(
+                {
+                    "n_files": len(paths),
+                    "n_chunks": len(flat_chunks),
+                    "results": [r.row() for r in results],
+                    "end_to_end_total_s": total,
+                },
+                indent=2,
+            )
+        )
+        print(f"[report] wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_bm25.py
+++ b/tests/test_bm25.py
@@ -121,13 +121,9 @@ def test_add_updates_df_incrementally(tmp_path: Path) -> None:
 # ----------------------------------------------------------------------
 
 
-def test_add_is_linear_not_quadratic(tmp_path: Path) -> None:
-    """Add 500 single-chunk docs one at a time; pre-fix took ~60+ s."""
-    idx = _Bm25Index(tmp_path / "scale.json")
-    # Single warm-up build so any import-time cost is amortised.
-    idx.build_index([])
+def _time_add(idx: _Bm25Index, start: int, n: int) -> float:
     t0 = time.perf_counter()
-    for i in range(500):
+    for i in range(start, start + n):
         idx.add_documents(
             [
                 {
@@ -136,11 +132,35 @@ def test_add_is_linear_not_quadratic(tmp_path: Path) -> None:
                 }
             ]
         )
-    elapsed = time.perf_counter() - t0
-    # Pre-fix reference for 500 per-file calls across ~3779 chunks was 67.7 s;
-    # 500 single-chunk calls on the quadratic path would be on the order of
-    # several seconds. 2.0 s is a very generous ceiling even on slow CI.
-    assert elapsed < 2.0, f"O(N^2) regression: 500 adds took {elapsed:.2f}s"
+    return time.perf_counter() - t0
+
+
+def test_add_is_linear_not_quadratic(tmp_path: Path) -> None:
+    """Assert scaling is linear-ish by comparing two run sizes.
+
+    O(N) adds → elapsed_500 / elapsed_50 ≈ 10×
+    O(N²) adds → elapsed_500 / elapsed_50 ≈ 100× (pre-fix actual was ~120×)
+
+    A threshold of 30× leaves plenty of headroom for noise on slow CI while
+    still catching a quadratic regression.  An env var lets operators raise
+    the threshold on exceptionally slow machines without patching the code.
+    """
+    idx = _Bm25Index(tmp_path / "scale.json")
+    idx.build_index([])
+
+    baseline = _time_add(idx, start=0, n=50)
+    big = _time_add(idx, start=50, n=500)
+
+    # Protect against divide-by-near-zero on ludicrously fast hardware.
+    baseline_floor = max(baseline, 1e-4)
+    ratio = big / baseline_floor
+    max_ratio = float(os.environ.get("BM25_LINEARITY_MAX_RATIO", "30"))
+
+    assert ratio < max_ratio, (
+        f"O(N^2) regression: 500 adds took {big:.3f}s vs 50-add baseline "
+        f"{baseline:.3f}s (ratio={ratio:.1f}x, threshold={max_ratio:.1f}x). "
+        "Linear scaling would be ~10x."
+    )
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_bm25.py
+++ b/tests/test_bm25.py
@@ -1,0 +1,290 @@
+"""Direct unit tests for the BM25 core + both wrapper modules.
+
+Each test is explicitly tied to a bug class it prevents. See
+``bench-results/FINDINGS.md`` for the benchmark that motivated these.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+from rank_bm25 import BM25Okapi
+
+from locallens._bm25_core import _Bm25Index, _tokenize
+
+FIXED_CORPUS = [
+    "the quick brown fox jumps over the lazy dog",
+    "pack my box with five dozen liquor jugs",
+    "sphinx of black quartz judge my vow",
+    "how vexingly quick daft zebras jump",
+    "bright vixens jump dozy fowl quack",
+    "amazingly few discotheques provide jukeboxes",
+    "the five boxing wizards jump quickly",
+    "jackdaws love my big sphinx of quartz",
+    "the quick brown dog runs over the lazy cat",
+    "fast foxes and lazy dogs share a meadow",
+    "quartz glass sparkles in the morning light",
+    "dogs and cats live together peacefully",
+    "rapid typing requires a calm mind",
+    "indexing documents efficiently matters",
+    "semantic search complements keyword search",
+    "hybrid ranking uses reciprocal rank fusion",
+    "offline tools protect personal privacy",
+    "a fox in the henhouse is a disaster",
+    "the lazy cat ignored the busy fox",
+    "wizards of light jump through hoops",
+]
+
+
+def _make_docs(texts: list[str], start: int = 0) -> list[dict]:
+    """Build doc dicts with a stable ``d{index}`` id. ``start`` is the offset
+    into the caller's master list so that ``_make_docs(FIXED_CORPUS[3:4],
+    start=3)`` produces ``d3`` — matching ``_make_docs(FIXED_CORPUS[:4])``'s
+    4th entry, not colliding with its first."""
+    return [{"id": f"d{i}", "chunk_text": t} for i, t in enumerate(texts, start=start)]
+
+
+def _rank_bm25_scores(corpus: list[str], query: str) -> list[float]:
+    """Reference scores from rank_bm25 for parity checks."""
+    tokenized = [_tokenize(t) for t in corpus]
+    bm = BM25Okapi(tokenized)
+    return list(bm.get_scores(_tokenize(query)))
+
+
+@pytest.fixture
+def idx(tmp_path: Path) -> _Bm25Index:
+    return _Bm25Index(tmp_path / "bm25.json")
+
+
+# ----------------------------------------------------------------------
+# 1 + 2 — Parity with rank_bm25 (prevents silent ranking / score drift)
+# ----------------------------------------------------------------------
+
+
+def test_build_index_matches_rank_bm25_ranking(idx: _Bm25Index) -> None:
+    idx.build_index(_make_docs(FIXED_CORPUS))
+    for query in ["fox", "lazy dog", "sphinx quartz", "jump", "indexing search"]:
+        ref = _rank_bm25_scores(FIXED_CORPUS, query)
+        ref_ranked = sorted(
+            [(f"d{i}", s) for i, s in enumerate(ref) if s > 0],
+            key=lambda x: x[1],
+            reverse=True,
+        )
+        ours = idx.search(query, top_k=len(FIXED_CORPUS))
+        # Compare the ordered doc_ids — ranking equality is the contract.
+        assert [d for d, _ in ours] == [d for d, _ in ref_ranked], (
+            f"ranking mismatch for query {query!r}: ours={ours} ref={ref_ranked}"
+        )
+
+
+def test_score_parity_within_epsilon(idx: _Bm25Index) -> None:
+    idx.build_index(_make_docs(FIXED_CORPUS))
+    for query in ["fox", "lazy dog", "sphinx quartz"]:
+        ref = _rank_bm25_scores(FIXED_CORPUS, query)
+        ours = dict(idx.search(query, top_k=len(FIXED_CORPUS)))
+        for i, ref_score in enumerate(ref):
+            if ref_score <= 0:
+                continue
+            our_score = ours.get(f"d{i}")
+            assert our_score is not None, f"missing d{i} for query {query!r}"
+            assert abs(our_score - ref_score) < 1e-9, (
+                f"score mismatch for d{i} query={query!r}: "
+                f"ours={our_score} ref={ref_score}"
+            )
+
+
+# ----------------------------------------------------------------------
+# 3 — Incremental df update (prevents rebuild-on-every-add regression)
+# ----------------------------------------------------------------------
+
+
+def test_add_updates_df_incrementally(tmp_path: Path) -> None:
+    idx_a = _Bm25Index(tmp_path / "a.json")
+    idx_a.build_index(_make_docs(FIXED_CORPUS[:3]))
+    idx_a.add_documents(_make_docs(FIXED_CORPUS[3:4], start=3))
+
+    idx_b = _Bm25Index(tmp_path / "b.json")
+    idx_b.build_index(_make_docs(FIXED_CORPUS[:4]))
+
+    assert idx_a.state.df == idx_b.state.df
+    assert idx_a.state.total_tokens == idx_b.state.total_tokens
+    assert idx_a.state.doc_lengths == idx_b.state.doc_lengths
+
+
+# ----------------------------------------------------------------------
+# 4 — Linearity (prevents the exact O(N^2) bug we're fixing)
+# ----------------------------------------------------------------------
+
+
+def test_add_is_linear_not_quadratic(tmp_path: Path) -> None:
+    """Add 500 single-chunk docs one at a time; pre-fix took ~60+ s."""
+    idx = _Bm25Index(tmp_path / "scale.json")
+    # Single warm-up build so any import-time cost is amortised.
+    idx.build_index([])
+    t0 = time.perf_counter()
+    for i in range(500):
+        idx.add_documents(
+            [
+                {
+                    "id": f"s{i}",
+                    "chunk_text": f"document number {i} with some filler text",
+                }
+            ]
+        )
+    elapsed = time.perf_counter() - t0
+    # Pre-fix reference for 500 per-file calls across ~3779 chunks was 67.7 s;
+    # 500 single-chunk calls on the quadratic path would be on the order of
+    # several seconds. 2.0 s is a very generous ceiling even on slow CI.
+    assert elapsed < 2.0, f"O(N^2) regression: 500 adds took {elapsed:.2f}s"
+
+
+# ----------------------------------------------------------------------
+# 5 — Remove recomputes idf (prevents stale idf after removal)
+# ----------------------------------------------------------------------
+
+
+def test_remove_recomputes_idf(idx: _Bm25Index) -> None:
+    idx.build_index(_make_docs(FIXED_CORPUS))
+    pre = dict(idx.search("sphinx", top_k=20))
+    assert pre, "expected 'sphinx' to match at least one doc pre-removal"
+
+    # Remove every doc that contains 'sphinx'.
+    to_remove = [
+        f"d{i}" for i, text in enumerate(FIXED_CORPUS) if "sphinx" in text.lower()
+    ]
+    assert to_remove, "test precondition: corpus must contain 'sphinx'"
+    idx.remove_documents(to_remove)
+
+    post = idx.search("sphinx", top_k=20)
+    assert post == [], f"expected empty search post-removal, got {post}"
+
+
+# ----------------------------------------------------------------------
+# 6 — In-place update (prevents df double-count on id replacement)
+# ----------------------------------------------------------------------
+
+
+def test_update_existing_doc_id(idx: _Bm25Index) -> None:
+    # Background corpus so rare terms ('alpha'/'delta') get positive idf.
+    idx.build_index(_make_docs(FIXED_CORPUS))
+    before_n = len(idx.state.doc_ids)
+
+    idx.add_documents([{"id": "foo", "chunk_text": "alpha beta gamma"}])
+    assert idx.search("alpha", top_k=5), "alpha should match before overwrite"
+    assert idx.search("delta", top_k=5) == []
+
+    idx.add_documents([{"id": "foo", "chunk_text": "delta epsilon zeta"}])
+    assert idx.search("alpha", top_k=5) == [], "alpha must not match after overwrite"
+    assert idx.search("delta", top_k=5), "delta should match after overwrite"
+    # The 'foo' replacement should leave doc-count unchanged at background + 1.
+    assert len(idx.state.doc_ids) == before_n + 1
+
+
+# ----------------------------------------------------------------------
+# 7 — Old-format JSON loads unchanged (prevents breaking existing indexes)
+# ----------------------------------------------------------------------
+
+
+def test_load_forward_compatible_with_old_json(tmp_path: Path) -> None:
+    """Write a file in the exact shape the pre-fix code produced, then load it.
+    The on-disk schema is unchanged post-fix, so this is a no-migration test."""
+    path = tmp_path / "old.json"
+    path.write_text(
+        json.dumps(
+            {
+                "doc_ids": [f"d{i}" for i in range(len(FIXED_CORPUS))],
+                "corpus_texts": list(FIXED_CORPUS),
+            }
+        )
+    )
+    idx = _Bm25Index(path)
+    idx.load()
+    assert idx.is_loaded()
+    # 'sphinx' appears in 2 of the 20 docs — idf is positive, so hits is non-empty.
+    hits = idx.search("sphinx", top_k=5)
+    assert hits, "expected 'sphinx' to match after loading old-format JSON"
+
+
+# ----------------------------------------------------------------------
+# 8 — Deferred flush + atexit safety
+# ----------------------------------------------------------------------
+
+
+def test_flush_is_deferred_and_idempotent(tmp_path: Path) -> None:
+    path = tmp_path / "defer.json"
+    idx = _Bm25Index(path)
+    # build_index is eager — gives us a baseline file on disk.
+    idx.build_index(_make_docs(FIXED_CORPUS[:2]))
+    baseline_mtime = path.stat().st_mtime_ns
+
+    # Sleep briefly so the fs timestamp resolution can register a change
+    # when/if it happens. Most linux fs have ns resolution; this is belt +
+    # suspenders on exotic targets.
+    time.sleep(0.01)
+
+    # Deferred mutation: file mtime should NOT change.
+    idx.add_documents(_make_docs(FIXED_CORPUS[2:4]))
+    assert path.stat().st_mtime_ns == baseline_mtime, "add_documents must defer"
+
+    idx.flush()
+    after_flush_mtime = path.stat().st_mtime_ns
+    assert after_flush_mtime > baseline_mtime, "flush must persist"
+
+    # Idempotent — second flush does nothing harmful.
+    idx.flush()
+    assert path.stat().st_mtime_ns == after_flush_mtime
+
+
+# ----------------------------------------------------------------------
+# 9 — Env escape hatch for eager persistence (debuggability)
+# ----------------------------------------------------------------------
+
+
+def test_eager_flush_env_override(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("LOCALLENS_BM25_EAGER_FLUSH", "1")
+    path = tmp_path / "eager.json"
+    idx = _Bm25Index(path)
+    idx.add_documents(_make_docs(FIXED_CORPUS[:1]))
+    assert path.exists(), "eager mode must persist on every mutation"
+    first_mtime = path.stat().st_mtime_ns
+
+    time.sleep(0.01)
+    idx.add_documents(_make_docs(FIXED_CORPUS[1:2]))
+    assert path.stat().st_mtime_ns > first_mtime
+
+
+# ----------------------------------------------------------------------
+# 10 — CLI and backend wrappers share the same core type
+# ----------------------------------------------------------------------
+
+
+def test_cli_and_backend_share_core() -> None:
+    from backend.app.services import bm25 as backend_bm25
+    from locallens import bm25 as cli_bm25
+
+    assert type(cli_bm25._index) is type(backend_bm25._index)
+
+
+# ----------------------------------------------------------------------
+# Wrapper-module sanity — _set_persist_path works end to end
+# ----------------------------------------------------------------------
+
+
+def test_wrapper_set_persist_path(tmp_path: Path) -> None:
+    from locallens import bm25 as cli_bm25
+
+    orig_path = cli_bm25._index.persist_path
+    redirect = tmp_path / "nested" / "idx.json"
+    try:
+        cli_bm25._set_persist_path(redirect)
+        assert cli_bm25._index.persist_path == redirect
+        cli_bm25.build_index([{"id": str(uuid.uuid4()), "chunk_text": "hello world"}])
+        assert redirect.exists()
+    finally:
+        # Restore so a later test doesn't see the redirect.
+        cli_bm25._set_persist_path(orig_path)


### PR DESCRIPTION
## Summary

The BM25 indexing pipeline was rebuilding the entire index and rewriting the full JSON file on every `add_documents()` call, resulting in O(N²) complexity when called once per file. This caused 500 files to take 67.7 seconds instead of the linear ~0.3 seconds, dominating end-to-end indexing time (96.9% of wall-clock time).

This PR replaces the naive rebuild-on-every-add approach with an incremental `_Bm25Index` class that maintains running document frequency and token counters, defers IDF recomputation until search, and batches persistence writes.

## Key Changes

- **New `locallens/_bm25_core.py`**: Core incremental BM25 implementation
  - `_Bm25Index` class with per-document term-frequency tracking
  - Lazy IDF recomputation (marked dirty on mutations, recomputed on first search)
  - Deferred persistence with `atexit` hook and explicit `flush()` for graceful shutdown
  - Maintains identical on-disk JSON format for backward compatibility
  - Ranking semantics match `rank_bm25.BM25Okapi` exactly (k1=1.5, b=0.75, epsilon=0.25)

- **Refactored `locallens/bm25.py` and `backend/app/services/bm25.py`**: Thin wrappers
  - Both now delegate to `_Bm25Index` instead of duplicating logic
  - Module-level API preserved: `build_index`, `add_documents`, `remove_documents`, `search`, `load`, `is_loaded`, `flush`
  - CLI uses `~/.locallens/bm25_index.json`; backend uses `data/bm25_index.json`

- **Updated callers**:
  - `locallens/indexer.py`: Added `bm25.flush()` at end of `index_folder()`
  - `backend/app/main.py`: Added `bm25.flush()` in FastAPI shutdown hook

- **Comprehensive test suite** (`tests/test_bm25.py`):
  - Parity tests against `rank_bm25.BM25Okapi` (ranking and scores)
  - Incremental df update correctness
  - Linearity regression test (500 single-chunk adds in <2s, vs 67.7s pre-fix)
  - IDF recomputation after removal
  - Persistence round-trip

- **Benchmark suite** (`scripts/bench_pipeline.py`):
  - Stage-by-stage pipeline profiling with synthetic corpus
  - Pre-fix results: 200 files (1,485 chunks) = 10.5s; 500 files (3,779 chunks) = 67.7s (6.4× scaling)
  - Post-fix results: 200 files = 53ms; 500 files = 141ms (linear scaling)
  - Detailed findings in `bench-results/FINDINGS.md`

## Implementation Details

- **Incremental updates**: `add_documents()` and `remove_documents()` now do O(1) per-document work instead of O(N) full-corpus retokenization and rebuild
- **Lazy IDF**: IDF is recomputed only when `search()` is called after a mutation, not on every add
- **Deferred writes**: Mutations mark the index dirty; actual JSON writes are batched and deferred until `flush()` or process exit
- **Thread-safe flush**: Module-level `threading.Lock` prevents interleaved partial writes between `atexit` hook and explicit `flush()` calls
- **Backward compatible**: On-disk JSON format unchanged; existing indexes load without migration

## Performance Impact

- **200 files**: 10.5s → 53ms (198× speedup)
- **500 files**: 67.7s → 141ms (480× speedup)
- Eliminates the dominant bottleneck in the indexing pipeline

https://claude.ai/code/session_01LnDmukgLakz4ZyYesrbpqX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a benchmarking tool and detailed benchmark reports to measure pipeline stages and performance.

* **Bug Fixes**
  * Fixed incremental indexing so BM25 indexing scales linearly (no O(n²) slowdown).
  * Ensured BM25 buffered state is persisted during shutdown and after indexing runs.

* **Chores**
  * Switched to a shared BM25 core for more reliable persistence and maintenance.
  * Added tests and an ignore entry for a generated version file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->