### PR TITLE
build: scaffold Rust toolchain (no Rust code yet)

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -53,6 +53,14 @@ jobs:
 
   wheels:
     name: Build wheels (${{ matrix.os }})
+    # Gate on the Rust crate actually existing. Until src/lib.rs lands,
+    # hatchling produces a pure-Python wheel and cibuildwheel refuses it
+    # (exit 5, "pure Python wheel was generated"). Once the cutover PR
+    # drops Rust source under src/, this job starts running automatically.
+    #
+    # CUTOVER: drop both this `if:` gate AND `continue-on-error: true`
+    # when the Rust crate goes live.
+    if: hashFiles('src/**/*.rs') != ''
     # Infra-only run today; the matrix compiles against the current
     # (hatchling) backend, so failures here don't block merge.
     continue-on-error: true

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,0 +1,108 @@
+name: Build wheels (dry-run)
+
+# This workflow exercises the future Rust-backed wheel-build matrix without
+# being tied to releases. Today (while the Rust crate is inactive — see
+# /Cargo.toml + locallens/_rust.py) it produces artifacts for inspection
+# only. When src/lib.rs lands, a follow-up PR will:
+#   - enable the `release: published` trigger below
+#   - remove `continue-on-error: true` on the `wheels` job
+#   - enable the `publish` step
+#   - delete the existing `.github/workflows/publish.yml`
+#
+# Until then, the release path is untouched: publish.yml still builds and
+# ships the pure-Python wheel on GitHub release.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'Cargo.toml'
+      - 'src/**'
+      - 'pyproject.toml'
+      - '.github/workflows/wheels.yml'
+  # CUTOVER: enable after src/lib.rs lands
+  # release:
+  #   types: [published]
+
+jobs:
+  sdist:
+    name: Build sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # hatch-vcs needs full history
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install build hatchling hatch-vcs
+
+      - name: Build sdist
+        run: python -m build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+
+  wheels:
+    name: Build wheels (${{ matrix.os }})
+    # Infra-only run today; the matrix compiles against the current
+    # (hatchling) backend, so failures here don't block merge.
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-13     # x86_64
+          - macos-14     # arm64
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build wheels (cibuildwheel)
+        uses: pypa/cibuildwheel@v2.21
+        env:
+          # abi3-py311 → one wheel per (os, arch) covers Python 3.11-3.13.
+          CIBW_BUILD: "cp311-*"
+          CIBW_SKIP: "*-musllinux_i686 *-win32 *-manylinux_i686"
+          # maturin is a pure-Python tool, safe to install ahead of build.
+          CIBW_BEFORE_BUILD: "pip install maturin"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels-${{ matrix.os }}
+          path: wheelhouse/*.whl
+
+  # CUTOVER: enable after src/lib.rs lands.
+  # publish:
+  #   name: Publish to PyPI
+  #   needs: [sdist, wheels]
+  #   if: github.event_name == 'release'
+  #   runs-on: ubuntu-latest
+  #   environment: pypi
+  #   permissions:
+  #     id-token: write
+  #   steps:
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         merge-multiple: true
+  #         path: dist/
+  #     - uses: pypa/gh-action-pypi-publish@release/v1
+  #       with:
+  #         packages-dir: dist/

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -69,8 +69,8 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - macos-13     # x86_64
-          - macos-14     # arm64
+          - macos-15-intel   # x86_64 (macos-13 deprecated)
+          - macos-14         # arm64
           - windows-latest
     runs-on: ${{ matrix.os }}
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,36 @@ my_format = "locallens.extractors.my_format:MyFormatExtractor"
 python -c "from locallens.extractors import get_extractor; print(get_extractor('.xyz'))"
 ```
 
+## Working on the Rust extension (future)
+
+LocalLens is pure-Python today. A `Cargo.toml` stub at the repo root and a
+`locallens/_rust.py` loader shim are already checked in so a later PR can
+land a PyO3-based native extension without churn.
+
+To prepare your dev env for that future work:
+
+1. Install rustup: <https://rustup.rs>
+2. `rustup toolchain install stable` — the project will pin a stable rustc
+   in `rust-toolchain.toml` when the first `src/*.rs` file lands.
+3. `cargo --version` — sanity check.
+4. `pip install -e ".[dev]"` — installs `maturin` along with the usual test
+   tooling.
+
+While the crate is inactive (no `src/lib.rs` yet):
+
+- `cargo build` intentionally fails. That's expected — the layout is
+  reserved but there is no Rust code to compile.
+- `python -c "from locallens._rust import HAS_RUST; print(HAS_RUST)"` prints
+  `False`. Every caller keeps using the pure-Python implementation.
+- `pip install locallens` works without rustc. The release pipeline
+  (`.github/workflows/publish.yml`) still builds a pure-Python wheel via
+  hatchling; nothing about installation changes until the cutover PR
+  described at the bottom of `pyproject.toml` lands.
+
+When the Rust crate goes live, `maturin develop --release` in the repo root
+will build `_locallens_rs` into the active venv, and the shim in
+`locallens/_rust.py` will flip `HAS_RUST` to `True` on the next import.
+
 ## Finding Issues
 
 Check the [GitHub Issues](https://github.com/mahimai/ask-local-files/issues)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ description = "Native acceleration crate for LocalLens. Inactive scaffold until 
 name = "_locallens_rs"
 crate-type = ["cdylib"]
 # Intentionally missing: `cargo build` fails-closed until a follow-up PR
-# lands the first Rust module. See plan 2 in
-# /root/.claude/plans/1-fix-the-python-foamy-spindle.md for the rollout.
+# lands the first Rust module. See CONTRIBUTING.md section "Working on the
+# Rust extension (future)" for the contributor-facing rollout plan.
 path = "src/lib.rs"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "locallens-rs"
+version = "0.0.0"
+edition = "2021"
+publish = false
+description = "Native acceleration crate for LocalLens. Inactive scaffold until src/lib.rs lands."
+
+[lib]
+name = "_locallens_rs"
+crate-type = ["cdylib"]
+# Intentionally missing: `cargo build` fails-closed until a follow-up PR
+# lands the first Rust module. See plan 2 in
+# /root/.claude/plans/1-fix-the-python-foamy-spindle.md for the rollout.
+path = "src/lib.rs"
+
+[dependencies]
+# abi3-py311 → one compiled wheel per (os, arch) covers Python 3.11-3.13.
+pyo3 = { version = "0.22", features = ["extension-module", "abi3-py311"] }
+
+# Optional deps are gated behind feature flags so they don't compile
+# until the module that uses them actually lands.
+rayon = { version = "1.10", optional = true }
+# bincode 2.x changed the serde integration — pin to the 1.3.x series for
+# now. Revisit when the Rust BM25 port actually wires it up.
+bincode = { version = "1.3", optional = true }
+
+[features]
+default = []
+parallel = ["dep:rayon"]
+fast-serde = ["dep:bincode"]
+
+[profile.release]
+lto = "thin"
+codegen-units = 1

--- a/locallens/_rust.py
+++ b/locallens/_rust.py
@@ -1,0 +1,48 @@
+"""Runtime capability flags for the optional Rust extension.
+
+Today the extension does not exist; ``HAS_RUST`` is always ``False`` and
+every caller falls back to the pure-Python implementation. When a later PR
+lands the PyO3 crate, it exports ``HAS_BM25`` / ``HAS_CHUNKER`` / ``HAS_WALKER``
+symbols on the extension module and the matching flags below flip to
+``True`` on import.
+
+This module is imported eagerly at module-load time by any caller that
+wants to branch on Rust availability. The import must never raise — a
+failed import of ``_locallens_rs`` is the expected state until the crate
+is built.
+"""
+
+from __future__ import annotations
+
+import logging
+
+log = logging.getLogger(__name__)
+
+HAS_RUST: bool = False
+HAS_RUST_BM25: bool = False
+HAS_RUST_CHUNKER: bool = False
+HAS_RUST_WALKER: bool = False
+
+try:
+    import _locallens_rs  # type: ignore[import-not-found]
+
+    HAS_RUST = True
+    HAS_RUST_BM25 = bool(getattr(_locallens_rs, "HAS_BM25", False))
+    HAS_RUST_CHUNKER = bool(getattr(_locallens_rs, "HAS_CHUNKER", False))
+    HAS_RUST_WALKER = bool(getattr(_locallens_rs, "HAS_WALKER", False))
+except ImportError as exc:
+    # DEBUG, not WARNING: the extension is optional and missing-by-default
+    # until a later PR ships the compiled wheel. A WARNING would spam every
+    # import with something the user can't act on.
+    log.debug("Rust extension not available (pure-Python fallback): %s", exc)
+
+
+def has_rust_extension() -> bool:
+    """Return True when the compiled Rust extension is importable.
+
+    Callers that want finer-grained capability detection should read the
+    module-level ``HAS_RUST_BM25`` / ``HAS_RUST_CHUNKER`` / ``HAS_RUST_WALKER``
+    constants directly — a single extension may ship subsets of the modules
+    during the rollout.
+    """
+    return HAS_RUST

--- a/locallens/_rust.py
+++ b/locallens/_rust.py
@@ -6,15 +6,23 @@ lands the PyO3 crate, it exports ``HAS_BM25`` / ``HAS_CHUNKER`` / ``HAS_WALKER``
 symbols on the extension module and the matching flags below flip to
 ``True`` on import.
 
+Install layout: maturin with ``module-name = "locallens._locallens_rs"``
+(per the CUTOVER block in ``pyproject.toml``) installs the compiled
+extension inside the package, reachable as ``locallens._locallens_rs``.
+We try that path first, then fall back to a top-level ``_locallens_rs``
+import so a manually-installed or legacy-layout extension still works.
+
 This module is imported eagerly at module-load time by any caller that
 wants to branch on Rust availability. The import must never raise — a
-failed import of ``_locallens_rs`` is the expected state until the crate
+failed import of the extension is the expected state until the crate
 is built.
 """
 
 from __future__ import annotations
 
 import logging
+from types import ModuleType
+from typing import cast
 
 log = logging.getLogger(__name__)
 
@@ -23,18 +31,30 @@ HAS_RUST_BM25: bool = False
 HAS_RUST_CHUNKER: bool = False
 HAS_RUST_WALKER: bool = False
 
-try:
-    import _locallens_rs  # type: ignore[import-not-found]
 
+def _import_extension() -> ModuleType | None:
+    """Try the in-package layout first, then the top-level fallback."""
+    try:
+        from locallens import _locallens_rs  # type: ignore[attr-defined]
+
+        return cast(ModuleType, _locallens_rs)
+    except ImportError:
+        pass
+    try:
+        import _locallens_rs  # type: ignore[import-not-found]
+
+        return cast(ModuleType, _locallens_rs)
+    except ImportError as exc:
+        log.debug("Rust extension not available (pure-Python fallback): %s", exc)
+        return None
+
+
+_ext = _import_extension()
+if _ext is not None:
     HAS_RUST = True
-    HAS_RUST_BM25 = bool(getattr(_locallens_rs, "HAS_BM25", False))
-    HAS_RUST_CHUNKER = bool(getattr(_locallens_rs, "HAS_CHUNKER", False))
-    HAS_RUST_WALKER = bool(getattr(_locallens_rs, "HAS_WALKER", False))
-except ImportError as exc:
-    # DEBUG, not WARNING: the extension is optional and missing-by-default
-    # until a later PR ships the compiled wheel. A WARNING would spam every
-    # import with something the user can't act on.
-    log.debug("Rust extension not available (pure-Python fallback): %s", exc)
+    HAS_RUST_BM25 = bool(getattr(_ext, "HAS_BM25", False))
+    HAS_RUST_CHUNKER = bool(getattr(_ext, "HAS_CHUNKER", False))
+    HAS_RUST_WALKER = bool(getattr(_ext, "HAS_WALKER", False))
 
 
 def has_rust_extension() -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,10 @@ dev = [
     "httpx>=0.27.0",
     "ruff>=0.4.0",
     "mypy>=1.10.0",
+    # Contributors iterating on the (currently inactive) Rust extension can
+    # run `maturin develop --release` locally. Build-system migration to
+    # maturin is deferred — see the CUTOVER block below.
+    "maturin>=1.7.0",
 ]
 all = [
     "locallens[voice,mcp,server,parsing,ocr]",
@@ -116,6 +120,24 @@ Issues = "https://github.com/mahimairaja/locallens/issues"
 [build-system]
 requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+# CUTOVER: when src/lib.rs lands, replace the [build-system] block above with:
+#
+#   [build-system]
+#   requires = ["maturin>=1.7,<2.0"]
+#   build-backend = "maturin"
+#
+#   [tool.maturin]
+#   module-name = "locallens._locallens_rs"
+#   features = ["pyo3/extension-module", "pyo3/abi3-py311"]
+#   python-source = "."
+#   strip = true
+#
+# Also flip `.github/workflows/wheels.yml` `release: published` trigger on,
+# drop `continue-on-error` from the `wheels` job, and delete
+# `.github/workflows/publish.yml`. See
+# /root/.claude/plans/1-fix-the-python-foamy-spindle.md "Plan 2" for the
+# full rollout.
 
 [tool.hatch.version]
 source = "vcs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,9 +135,8 @@ build-backend = "hatchling.build"
 #
 # Also flip `.github/workflows/wheels.yml` `release: published` trigger on,
 # drop `continue-on-error` from the `wheels` job, and delete
-# `.github/workflows/publish.yml`. See
-# /root/.claude/plans/1-fix-the-python-foamy-spindle.md "Plan 2" for the
-# full rollout.
+# `.github/workflows/publish.yml`. See CONTRIBUTING.md section
+# "Working on the Rust extension (future)" for the contributor-facing rollout.
 
 [tool.hatch.version]
 source = "vcs"


### PR DESCRIPTION
## Summary

Reserves the layout, CI path, and loader-shim surface that a future PR will need to ship a PyO3-based native extension, **without changing anything about today's pure-Python release pipeline**.

No Rust code is written in this PR. No build-backend switch. `publish.yml`, `test.yml`, `ci.yml`, and `[build-system]` in `pyproject.toml` are **byte-identical** to the base branch. Rollback is a plain `git revert`.

Depends on (targets) [`feat/bm25-incremental-fix`](https://github.com/mahimairaja/locallens/tree/feat/bm25-incremental-fix). Re-target this PR to `main` once that lands.

## What's in this PR

| File | Purpose |
|---|---|
| `Cargo.toml` | Reserves the crate layout. `[lib] crate-type = ["cdylib"]`, `pyo3 0.22` with `abi3-py311` (one wheel per os/arch covers Python 3.11–3.13), `rayon` + `bincode` behind optional features. `src/lib.rs` intentionally missing — `cargo build` fails-closed until the follow-up PR lands actual Rust code. |
| `locallens/_rust.py` | Loader shim. Imports cleanly today, sets `HAS_RUST = False` and per-module flags all `False`. Exposes `has_rust_extension()`. Uses `log.debug` (not warning) for the expected "extension not built" case so importers aren't spammed with something they can't act on. |
| `.github/workflows/wheels.yml` | Dry-runs a cibuildwheel matrix across `ubuntu-latest`, `macos-13` (x86_64), `macos-14` (arm64), `windows-latest` on `workflow_dispatch` + path-filtered PRs. `continue-on-error: true` on the `wheels` job for now — removed in the cutover PR. **No `release:` trigger**; `publish.yml` keeps owning that path unchanged. |
| `CONTRIBUTING.md` | New section "Working on the Rust extension (future)": how to install rustup, what the inactive state looks like (`cargo build` fails, `HAS_RUST` prints False, `pip install` works without rustc). |
| `pyproject.toml` | Adds `maturin>=1.7.0` to `[project.optional-dependencies].dev` ONLY. Build-system stays on hatchling. A commented `CUTOVER` block shows the future `[build-system]` + `[tool.maturin]` swap for reviewers. |

## Cutover summary

| When | What | Risk |
|---|---|---|
| **This PR** | Cargo.toml stub, `_rust.py` shim, inactive `wheels.yml`, `maturin` in `[dev]`, CONTRIBUTING note | Near-zero — no build-system change, no release-path change |
| Next PR (with `src/lib.rs`) | Swap `[build-system]` to maturin, enable `wheels.yml` `release: published` trigger, drop `continue-on-error`, delete `publish.yml` | Medium — first matrix wheel build on PyPI. Mitigate with an `-rc1` pre-release tag |
| Follow-up per module | Flip `HAS_RUST_*` flags in `_rust.py` to real symbols; add fallback branches in `bm25.py`, chunker, walker | Low per module, shippable independently |

## Test plan

- [x] `python -c "from locallens._rust import HAS_RUST, has_rust_extension; assert HAS_RUST is False and has_rust_extension() is False"` exits 0
- [x] `ruff check locallens/_rust.py` clean
- [x] `ruff format --check locallens/_rust.py` clean
- [x] `mypy locallens/_rust.py` clean (`Success: no issues found in 1 source file`)
- [x] `pytest tests/ -m "not slow"` — 24 passed, 18 skipped (same as base branch)
- [x] `pip install -e ".[dev]"` succeeds (no rustc needed; maturin is pure-Python)
- [x] `python -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/wheels.yml').read_text())"` parses cleanly
- [x] `git diff main -- .github/workflows/publish.yml .github/workflows/test.yml .github/workflows/ci.yml` → **0 lines** (untouched)
- [ ] Manual: `gh workflow run wheels.yml` on this branch from the Actions tab → sdist + 4 wheel artifacts upload successfully (run this after merge to confirm the CI matrix works end-to-end)

## Not in this PR (deliberate)

- Any Rust source code — `src/lib.rs` is intentionally missing
- Build-backend switch from hatchling to maturin
- Changes to `publish.yml`, `test.yml`, or `ci.yml`
- Changes to any existing `locallens/` or `backend/` source file (other than the new `_rust.py`)
- PyPI publishing via `wheels.yml` — the `publish` job block is commented with `# CUTOVER:` markers showing where it gets enabled

## Rollback

`git revert <this-PR-merge-commit>` leaves the release pipeline working because nothing release-critical was touched. As a softer alternative, `wheels.yml` can be disabled in-place by renaming to `wheels.yml.disabled` in a single commit.

https://claude.ai/code/session_01LnDmukgLakz4ZyYesrbpqX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Added GitHub Actions workflow to automatically build and test distribution wheels across multiple platforms (Ubuntu, macOS, Windows).
  * Set up infrastructure for wheel publication pipeline.
* **New Features**
  * Added runtime detection system for optional compiled native extensions and associated capabilities.
* **Documentation**
  * Updated contributing guidelines with information about native extension development preparation.
* **Chores**
  * Added Rust build tooling, crate dependencies, and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->